### PR TITLE
feat: enhance task and flow management

### DIFF
--- a/templates/flow.html
+++ b/templates/flow.html
@@ -2,6 +2,17 @@
 {% block content %}
 <h1 class="h3 mb-3">定義流程</h1>
 
+{% macro render_tree(node) %}
+<ul class="list-group ms-3 mb-0">
+  {% for fname in node.files %}
+    <li class="list-group-item">{{ fname }}</li>
+  {% endfor %}
+  {% for dname, dnode in node.dirs.items() %}
+    <li class="list-group-item"><strong>{{ dname }}</strong>{{ render_tree(dnode) }}</li>
+  {% endfor %}
+</ul>
+{% endmacro %}
+
 <form action="{{ url_for('run_flow', task_id=task.id) }}" method="post" class="vstack gap-3">
   <input type="hidden" name="ordered_ids" id="ordered_ids" value="">
   <div id="steps" class="vstack gap-3"></div>
@@ -32,19 +43,29 @@
 </div>
 <hr>
 <h2 class="h5 mt-4">已保存的流程</h2>
-<ul>
+<table class="table table-striped">
+  <thead>
+    <tr><th>名稱</th><th>建立時間</th><th class="text-end">操作</th></tr>
+  </thead>
+  <tbody>
   {% for f in flows %}
-  <li>{{ f.name }}
-    <a href="{{ url_for('flow_builder', task_id=task.id, flow=f.name) }}">編輯</a>
-    <form action="{{ url_for('delete_flow', task_id=task.id, flow_name=f.name) }}" method="post" style="display:inline">
-      <button class="btn btn-link p-0" type="submit">刪除</button>
-    </form>
-    <a href="{{ url_for('export_flow', task_id=task.id, flow_name=f.name) }}">匯出</a>
-  </li>
+    <tr>
+      <td>{{ f.name }}</td>
+      <td>{{ f.created }}</td>
+      <td class="text-end">
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('flow_builder', task_id=task.id, flow=f.name) }}">編輯</a>
+        <button class="btn btn-sm btn-outline-secondary" type="button" onclick="renameFlow('{{ f.name }}')">重新命名</button>
+        <form action="{{ url_for('delete_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline" onsubmit="return confirm('確定刪除?')">
+          <button class="btn btn-sm btn-outline-danger">刪除</button>
+        </form>
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('export_flow', task_id=task.id, flow_name=f.name) }}">匯出</a>
+      </td>
+    </tr>
   {% else %}
-  <li>尚無流程</li>
+    <tr><td colspan="3">尚無流程</td></tr>
   {% endfor %}
-</ul>
+  </tbody>
+</table>
 
 <form action="{{ url_for('import_flow', task_id=task.id) }}" method="post" enctype="multipart/form-data" class="mt-3">
   <div class="row g-3 align-items-end">
@@ -58,7 +79,11 @@
   </div>
 </form>
 
+<h2 class="h5 mt-4">檔案結構</h2>
+{{ render_tree(files_tree) }}
+
 <script>
+const TASK_ID = '{{ task.id }}';
 const SUPPORTED_STEPS = {{ steps|tojson }};
 const AVAILABLE_FILES = {{ files|tojson }};
 const PRESET_FLOW = {{ preset|tojson }};
@@ -185,6 +210,20 @@ function moveDown(sid){
   const next = el.nextElementSibling;
   if (next) el.parentNode.insertBefore(next, el);
   updateOrder();
+}
+function renameFlow(current){
+  const name = prompt('輸入新流程名稱', current);
+  if(!name) return;
+  const form = document.createElement('form');
+  form.method = 'post';
+  form.action = `/tasks/${TASK_ID}/flows/rename/${current}`;
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'name';
+  input.value = name;
+  form.appendChild(input);
+  document.body.appendChild(form);
+  form.submit();
 }
 if (PRESET_FLOW){
   for (const st of PRESET_FLOW){

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -2,12 +2,19 @@
 {% block content %}
 <h1 class="h4 mb-3">{{ task.name }}</h1>
 
-<h2 class="h6">檔案結構</h2>
-<ul class="list-group mb-3">
-{% for f in files %}
-  <li class="list-group-item">{{ f }}</li>
-{% endfor %}
+{% macro render_tree(node) %}
+<ul class="list-group ms-3 mb-0">
+  {% for fname in node.files %}
+    <li class="list-group-item">{{ fname }}</li>
+  {% endfor %}
+  {% for dname, dnode in node.dirs.items() %}
+    <li class="list-group-item"><strong>{{ dname }}</strong>{{ render_tree(dnode) }}</li>
+  {% endfor %}
 </ul>
+{% endmacro %}
+
+<h2 class="h6">檔案結構</h2>
+{{ render_tree(files_tree) }}
 
 <div class="d-flex gap-2">
   <a class="btn btn-primary" href="{{ url_for('flow_builder', task_id=task.id) }}">管理流程</a>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -29,6 +29,7 @@
       <td><a href="{{ url_for('task_detail', task_id=t.id) }}">{{ t.name }}</a></td>
       <td>{{ t.created }}</td>
       <td class="text-end">
+        <button class="btn btn-sm btn-outline-secondary" type="button" onclick="renameTask('{{ t.id }}', '{{ t.name }}')">重新命名</button>
         <form action="{{ url_for('delete_task', task_id=t.id) }}" method="post" class="d-inline" onsubmit="return confirm('確定刪除?')">
           <button class="btn btn-sm btn-outline-danger">刪除</button>
         </form>
@@ -39,5 +40,21 @@
   {% endfor %}
   </tbody>
 </table>
+<script>
+function renameTask(id, current){
+  const name = prompt('輸入新名稱', current);
+  if(!name) return;
+  const form = document.createElement('form');
+  form.method = 'post';
+  form.action = `/tasks/${id}/rename`;
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'name';
+  input.value = name;
+  form.appendChild(input);
+  document.body.appendChild(form);
+  form.submit();
+}
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- prevent creating duplicate task names and support renaming existing tasks
- list saved flows with creation time and rename option
- show folder-based file structure in task details and flow builder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d9ab7b41c83239ebe9e8175734c71