### PR TITLE
Improve file structure view and flow builder UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,7 +211,6 @@ def flow_builder(task_id):
             else:
                 preset = data
     avail = gather_available_files(files_dir)
-    tree = build_file_tree(files_dir)
     return render_template(
         "flow.html",
         task={"id": task_id},
@@ -220,7 +219,6 @@ def flow_builder(task_id):
         flows=flows,
         preset=preset,
         loaded_name=loaded_name,
-        files_tree=tree,
     )
 
 

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -2,17 +2,6 @@
 {% block content %}
 <h1 class="h3 mb-3">定義流程</h1>
 
-{% macro render_tree(node) %}
-<ul class="list-group ms-3 mb-0">
-  {% for fname in node.files %}
-    <li class="list-group-item">{{ fname }}</li>
-  {% endfor %}
-  {% for dname, dnode in node.dirs.items() %}
-    <li class="list-group-item"><strong>{{ dname }}</strong>{{ render_tree(dnode) }}</li>
-  {% endfor %}
-</ul>
-{% endmacro %}
-
 <form action="{{ url_for('run_flow', task_id=task.id) }}" method="post" class="vstack gap-3">
   <input type="hidden" name="ordered_ids" id="ordered_ids" value="">
   <div id="steps" class="vstack gap-3"></div>
@@ -29,7 +18,7 @@
       <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">新增步驟</button>
       <ul class="dropdown-menu">
         {% for key, meta in steps.items() %}
-        <li><a class="dropdown-item" href="#" onclick="addStep('{{ key|e }}')">{{ meta.label }}</a></li>
+        <li><a class="dropdown-item" href="#" onclick="addStep('{{ key|e }}'); return false;">{{ meta.label }}</a></li>
         {% endfor %}
       </ul>
     </div>
@@ -78,9 +67,6 @@
     </div>
   </div>
 </form>
-
-<h2 class="h5 mt-4">檔案結構</h2>
-{{ render_tree(files_tree) }}
 
 <script>
 const TASK_ID = '{{ task.id }}';

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -2,19 +2,24 @@
 {% block content %}
 <h1 class="h4 mb-3">{{ task.name }}</h1>
 
-{% macro render_tree(node) %}
-<ul class="list-group ms-3 mb-0">
-  {% for fname in node.files %}
-    <li class="list-group-item">{{ fname }}</li>
-  {% endfor %}
+{% macro render_tables(node, path="") %}
+  {% if node.files %}
+  <h3 class="h6 mt-3">{{ path or '根目錄' }}</h3>
+  <table class="table table-sm">
+    <tbody>
+      {% for fname in node.files %}
+      <tr><td>{{ fname }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
   {% for dname, dnode in node.dirs.items() %}
-    <li class="list-group-item"><strong>{{ dname }}</strong>{{ render_tree(dnode) }}</li>
+    {{ render_tables(dnode, path ~ ("/" if path else "") ~ dname) }}
   {% endfor %}
-</ul>
 {% endmacro %}
 
 <h2 class="h6">檔案結構</h2>
-{{ render_tree(files_tree) }}
+{{ render_tables(files_tree) }}
 
 <div class="d-flex gap-2">
   <a class="btn btn-primary" href="{{ url_for('flow_builder', task_id=task.id) }}">管理流程</a>


### PR DESCRIPTION
## Summary
- Display task files grouped by folder in tables
- Hide file tree on flow builder page and simplify backend
- Prevent page from jumping to top when adding steps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d9ed058588323bbe756c2743cba63