### PR TITLE
feat: add task description and center table headers

### DIFF
--- a/templates/flow.html
+++ b/templates/flow.html
@@ -34,7 +34,11 @@
 <h2 class="h5 mt-4">已保存的流程</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>名稱</th><th>建立時間</th><th class="text-end">操作</th></tr>
+    <tr>
+      <th class="text-center">名稱</th>
+      <th class="text-center">建立時間</th>
+      <th class="text-center">操作</th>
+    </tr>
   </thead>
   <tbody>
   {% for f in flows %}

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="h4 mb-3">{{ task.name }}</h1>
+<h1 class="h4 mb-1">{{ task.name }}</h1>
+{% if task.description %}
+<p class="text-muted mb-3">{{ task.description }}</p>
+{% else %}
+<div class="mb-3"></div>
+{% endif %}
 
 {% macro render_tables(node, path="") %}
   {% if node.files %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -15,18 +15,28 @@
     <div class="col-md-2 d-grid align-items-end">
       <button class="btn btn-primary" type="submit">建立任務</button>
     </div>
+    <div class="col-md-12">
+      <label class="form-label">任務描述</label>
+      <textarea class="form-control" name="task_desc" placeholder="輸入任務描述"></textarea>
+    </div>
   </div>
 </form>
 
 <h2 class="h5">現有任務</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>名稱</th><th>建立時間</th><th class="text-end">操作</th></tr>
+    <tr>
+      <th class="text-center">名稱</th>
+      <th class="text-center">描述</th>
+      <th class="text-center">建立時間</th>
+      <th class="text-center">操作</th>
+    </tr>
   </thead>
   <tbody>
   {% for t in tasks %}
     <tr>
       <td><a href="{{ url_for('task_detail', task_id=t.id) }}">{{ t.name }}</a></td>
+      <td>{{ t.description }}</td>
       <td>{{ t.created }}</td>
       <td class="text-end">
         <button class="btn btn-sm btn-outline-secondary" type="button" onclick="renameTask('{{ t.id }}', '{{ t.name }}')">重新命名</button>
@@ -36,7 +46,7 @@
       </td>
     </tr>
   {% else %}
-    <tr><td colspan="3">目前沒有任務</td></tr>
+    <tr><td colspan="4">目前沒有任務</td></tr>
   {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- allow adding textual description when creating tasks and show it in lists and details
- center column headers for task list and saved flows tables

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a287cd217c83239f73f394f18ea2e4