### PR TITLE
Add logo next to site title

### DIFF
--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <rect width="40" height="40" fill="#004b8d"/>
+  <text x="20" y="22" font-size="16" text-anchor="middle" fill="white" font-family="Arial">UO</text>
+</svg>

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,10 @@
   <body>
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom">
       <div class="container d-flex">
-        <a class="navbar-brand fw-bold me-auto" href="{{ url_for('tasks') }}">uo法規</a>
+        <a class="navbar-brand fw-bold me-auto d-flex align-items-center" href="{{ url_for('tasks') }}">
+          uo法規
+          <img src="{{ url_for('static', filename='logo.svg') }}" alt="Logo" class="ms-2" style="height:24px;">
+        </a>
         <a class="btn btn-outline-primary" href="{{ url_for('tasks') }}">回首頁</a>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- display a small UO logo next to the `uo法規` title in the navigation bar
- include SVG logo asset in the app's static files

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a295428d008323a6feed05108618f3