### PR TITLE
Add execute button for saved flows

### DIFF
--- a/templates/flow.html
+++ b/templates/flow.html
@@ -45,15 +45,18 @@
       <td>{{ f.name }}</td>
       <td>{{ f.created }}</td>
       <td>
+        <form action="{{ url_for('execute_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline">
+          <button class="btn btn-sm btn-outline-success">執行</button>
+        </form>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('flow_builder', task_id=task.id, flow=f.name) }}">編輯</a>
         <button class="btn btn-sm btn-outline-secondary" type="button" onclick="renameFlow('{{ f.name }}')">重新命名</button>
         <form action="{{ url_for('delete_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline" onsubmit="return confirm('確定刪除?')">
           <button class="btn btn-sm btn-outline-danger">刪除</button>
         </form>
-        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('export_flow', task_id=task.id, flow_name=f.name) }}">匯出</a>
-      </td>
-    </tr>
-  {% else %}
+          <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('export_flow', task_id=task.id, flow_name=f.name) }}">匯出</a>
+        </td>
+      </tr>
+    {% else %}
     <tr><td colspan="3">尚無流程</td></tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- add endpoint to execute saved flow definitions
- add run button for saved flows in flow builder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a2b8b87ccc832384911031f3acf4f3