### PR TITLE
refactor: move centering step to optional checkbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 from modules.workflow import SUPPORTED_STEPS, run_workflow
+from modules.Extract_AllFile_to_FinalWord import center_table_figure_paragraphs
 
 app = Flask(__name__, instance_relative_config=True)
 app.config["SECRET_KEY"] = "dev-secret"
@@ -219,16 +220,27 @@ def flow_builder(task_id):
                 pass
             flows.append({"name": os.path.splitext(fn)[0], "created": created})
     preset = None
+    center_titles = False
     loaded_name = request.args.get("flow")
     if loaded_name:
         p = os.path.join(flow_dir, f"{loaded_name}.json")
         if os.path.exists(p):
             with open(p, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            if isinstance(data, dict) and "steps" in data:
-                preset = data["steps"]
+            if isinstance(data, dict):
+                steps_data = data.get("steps", [])
+                center_titles = data.get("center_titles", False) or any(
+                    isinstance(s, dict) and s.get("type") == "center_table_figure_paragraphs" for s in steps_data
+                )
             else:
-                preset = data
+                steps_data = data
+                center_titles = any(
+                    isinstance(s, dict) and s.get("type") == "center_table_figure_paragraphs" for s in steps_data
+                )
+            preset = [
+                s for s in steps_data
+                if isinstance(s, dict) and s.get("type") in SUPPORTED_STEPS
+            ]
     avail = gather_available_files(files_dir)
     return render_template(
         "flow.html",
@@ -238,6 +250,7 @@ def flow_builder(task_id):
         flows=flows,
         preset=preset,
         loaded_name=loaded_name,
+        center_titles=center_titles,
     )
 
 
@@ -250,13 +263,14 @@ def run_flow(task_id):
     action = request.form.get("action", "run")
     flow_name = request.form.get("flow_name", "").strip()
     ordered_ids = request.form.get("ordered_ids", "").split(",")
+    center_titles = request.form.get("center_titles") == "on"
     workflow = []
     for sid in ordered_ids:
         sid = sid.strip()
         if not sid:
             continue
         stype = request.form.get(f"step_{sid}_type", "")
-        if not stype:
+        if not stype or stype not in SUPPORTED_STEPS:
             continue
         schema = SUPPORTED_STEPS.get(stype, {})
         params = {}
@@ -280,7 +294,7 @@ def run_flow(task_id):
                     created = data["created"]
             except Exception:
                 pass
-        data = {"created": created, "steps": workflow}
+        data = {"created": created, "steps": workflow, "center_titles": center_titles}
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         return redirect(url_for("flow_builder", task_id=task_id))
@@ -288,6 +302,8 @@ def run_flow(task_id):
     runtime_steps = []
     for step in workflow:
         stype = step["type"]
+        if stype not in SUPPORTED_STEPS:
+            continue
         schema = SUPPORTED_STEPS.get(stype, {})
         params = {}
         for k, v in step["params"].items():
@@ -302,6 +318,8 @@ def run_flow(task_id):
     job_dir = os.path.join(tdir, "jobs", job_id)
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
+    if center_titles:
+        center_table_figure_paragraphs(os.path.join(job_dir, "result.docx"))
     return redirect(url_for("task_result", task_id=task_id, job_id=job_id))
 
 
@@ -317,13 +335,21 @@ def execute_flow(task_id, flow_name):
         abort(404)
     with open(flow_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    if isinstance(data, dict) and "steps" in data:
-        workflow = data["steps"]
+    if isinstance(data, dict):
+        workflow = data.get("steps", [])
+        center_titles = data.get("center_titles", False) or any(
+            isinstance(s, dict) and s.get("type") == "center_table_figure_paragraphs" for s in workflow
+        )
     else:
         workflow = data
+        center_titles = any(
+            isinstance(s, dict) and s.get("type") == "center_table_figure_paragraphs" for s in workflow
+        )
     runtime_steps = []
     for step in workflow:
         stype = step.get("type")
+        if stype not in SUPPORTED_STEPS:
+            continue
         schema = SUPPORTED_STEPS.get(stype, {})
         params = {}
         for k, v in step.get("params", {}).items():
@@ -337,6 +363,8 @@ def execute_flow(task_id, flow_name):
     job_dir = os.path.join(tdir, "jobs", job_id)
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
+    if center_titles:
+        center_table_figure_paragraphs(os.path.join(job_dir, "result.docx"))
     return redirect(url_for("task_result", task_id=task_id, job_id=job_id))
 
 

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -8,8 +8,7 @@ from .Edit_Word import insert_text, insert_numbered_heading, insert_roman_headin
 from .Extract_AllFile_to_FinalWord import (
     extract_pdf_chapter_to_table,
     extract_word_all_content,
-    extract_word_chapter,
-    center_table_figure_paragraphs
+    extract_word_chapter
 )
 
 SUPPORTED_STEPS = {
@@ -47,11 +46,6 @@ SUPPORTED_STEPS = {
         "label": "插入項目符號標題",
         "inputs": ["text", "font_size"],
         "accepts": {"text":"text","font_size":"float"}
-    },
-    "center_table_figure_paragraphs": {
-        "label": "置中 Table/Figure 標題段落",
-        "inputs": ["input_file"],
-        "accepts": {"input_file": "file:docx"}
     }
 }
 
@@ -98,16 +92,6 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     output_doc=output_doc,
                     section=section
                 )
-
-            elif stype == "center_table_figure_paragraphs":
-                infile = params["input_file"]
-                center_table_figure_paragraphs(infile)
-                d = Document(); d.LoadFromFile(infile)
-                for si in range(d.Sections.Count):
-                    s2 = d.Sections.get_Item(si)
-                    for j in range(s2.ChildObjects.Count):
-                        section.ChildObjects.Add(s2.ChildObjects.get_Item(j).Clone())
-                d.Close()
 
             elif stype == "insert_text":
                 insert_text(section,

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -13,6 +13,11 @@
     </div>
   </div>
 
+  <div class="form-check">
+    <input class="form-check-input" type="checkbox" id="center_titles" name="center_titles" {% if center_titles %}checked{% endif %}>
+    <label class="form-check-label" for="center_titles">置中 Table/Figure 標題段落</label>
+  </div>
+
   <div class="d-flex gap-2 mt-2">
     <div class="dropdown">
       <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">新增步驟</button>


### PR DESCRIPTION
## Summary
- move Table/Figure title centering from workflow steps to an optional checkbox
- apply centering after workflow runs for new and saved flows

## Testing
- `python -m py_compile app.py modules/workflow.py modules/Extract_AllFile_to_FinalWord.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2dcaa395883238b6b58765e058f24