### PR TITLE
Use dropdown for text alignment

### DIFF
--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -30,7 +30,7 @@ SUPPORTED_STEPS = {
     "insert_text": {
         "label": "插入純文字段落",
         "inputs": ["text", "align", "bold", "font_size", "before_space", "after_space", "page_break_before"],
-        "accepts": {"text":"text","align":"text","bold":"bool","font_size":"float","before_space":"float","after_space":"float","page_break_before":"bool"}
+        "accepts": {"text":"text","align":"align","bold":"bool","font_size":"float","before_space":"float","after_space":"float","page_break_before":"bool"}
     },
     "insert_numbered_heading": {
         "label": "插入阿拉伯數字標題",


### PR DESCRIPTION
## Summary
- mark plain-text insertion alignment as a distinct "align" type so UI renders a dropdown instead of text input

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a2e4578068832384a52afeb0a6e892