### PR TITLE
feat: renumber table and figure captions

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,10 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 from modules.workflow import SUPPORTED_STEPS, run_workflow
-from modules.Extract_AllFile_to_FinalWord import center_table_figure_paragraphs
+from modules.Extract_AllFile_to_FinalWord import (
+    center_table_figure_paragraphs,
+    renumber_table_figure_titles,
+)
 
 app = Flask(__name__, instance_relative_config=True)
 app.config["SECRET_KEY"] = "dev-secret"
@@ -316,6 +319,7 @@ def run_flow(task_id):
     job_dir = os.path.join(tdir, "jobs", job_id)
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
+    renumber_table_figure_titles(os.path.join(job_dir, "result.docx"))
     if center_titles:
         center_table_figure_paragraphs(os.path.join(job_dir, "result.docx"))
     return redirect(url_for("task_result", task_id=task_id, job_id=job_id))
@@ -359,6 +363,7 @@ def execute_flow(task_id, flow_name):
     job_dir = os.path.join(tdir, "jobs", job_id)
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
+    renumber_table_figure_titles(os.path.join(job_dir, "result.docx"))
     if center_titles:
         center_table_figure_paragraphs(os.path.join(job_dir, "result.docx"))
     return redirect(url_for("task_result", task_id=task_id, job_id=job_id))

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -274,3 +274,102 @@ def center_table_figure_paragraphs(input_file: str) -> bool:
         return False
     finally:
         doc.Close()
+
+
+def renumber_table_figure_titles(input_file: str) -> bool:
+    """Renumber Table/Figure captions and update references.
+
+    Parameters
+    ----------
+    input_file: str
+        Path to the docx file whose captions should be renumbered.
+    """
+    caption_pattern = re.compile(r'^\s*(Table|Figure)\s+(\d+)', re.IGNORECASE)
+    ref_pattern = re.compile(r'(Table|Figure)\s+(\d+)', re.IGNORECASE)
+
+    doc = Document()
+    try:
+        doc.LoadFromFile(input_file)
+    except Exception as e:
+        print(f"錯誤：無法加載文件 {input_file}: {str(e)}")
+        return False
+
+    table_map = {}
+    figure_map = {}
+    table_idx = 1
+    figure_idx = 1
+
+    nodes = queue.Queue()
+    nodes.put(doc)
+    # 第一遍：重新編號圖表標題
+    while nodes.qsize() > 0:
+        node = nodes.get()
+        for i in range(node.ChildObjects.Count):
+            child = node.ChildObjects.get_Item(i)
+            if isinstance(child, Paragraph):
+                paragraph_text = ""
+                if child.ListText:
+                    paragraph_text += child.ListText + " "
+                for j in range(child.ChildObjects.Count):
+                    sub = child.ChildObjects.get_Item(j)
+                    if sub.DocumentObjectType == DocumentObjectType.TextRange:
+                        paragraph_text += sub.Text
+                paragraph_text = paragraph_text.strip()
+                match = caption_pattern.match(paragraph_text)
+                if match:
+                    kind, num = match.groups()
+                    num = int(num)
+                    if kind.lower() == "table":
+                        table_map[num] = table_idx
+                        new_text = caption_pattern.sub(f"Table {table_idx}", paragraph_text)
+                        table_idx += 1
+                    else:
+                        figure_map[num] = figure_idx
+                        new_text = caption_pattern.sub(f"Figure {figure_idx}", paragraph_text)
+                        figure_idx += 1
+                    child.ChildObjects.Clear()
+                    child.AppendText(new_text)
+            elif isinstance(child, ICompositeObject):
+                nodes.put(child)
+
+    def replace_refs(text: str) -> str:
+        def repl(m):
+            kind, num = m.group(1), int(m.group(2))
+            if kind.lower() == "table":
+                new_num = table_map.get(num, num)
+            else:
+                new_num = figure_map.get(num, num)
+            return f"{kind} {new_num}"
+        return ref_pattern.sub(repl, text)
+
+    nodes = queue.Queue()
+    nodes.put(doc)
+    # 第二遍：更新文中的引用
+    while nodes.qsize() > 0:
+        node = nodes.get()
+        for i in range(node.ChildObjects.Count):
+            child = node.ChildObjects.get_Item(i)
+            if isinstance(child, Paragraph):
+                paragraph_text = ""
+                if child.ListText:
+                    paragraph_text += child.ListText + " "
+                for j in range(child.ChildObjects.Count):
+                    sub = child.ChildObjects.get_Item(j)
+                    if sub.DocumentObjectType == DocumentObjectType.TextRange:
+                        paragraph_text += sub.Text
+                new_text = replace_refs(paragraph_text)
+                if new_text != paragraph_text:
+                    child.ChildObjects.Clear()
+                    child.AppendText(new_text)
+            elif isinstance(child, ICompositeObject):
+                nodes.put(child)
+
+    try:
+        doc.SaveToFile(input_file, FileFormat.Docx)
+        print(f"{input_file}，已重新編號 Table 和 Figure 並更新引用")
+        return True
+    except Exception as e:
+        print(f"錯誤：保存文件 {input_file} 時出錯: {str(e)}")
+        return False
+    finally:
+        doc.Close()


### PR DESCRIPTION
## Summary
- add utility to renumber Table/Figure captions and update in-text references
- invoke renumbering after workflow execution before optional centering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a44770c3f4832385aeb575bd2e3374