### PR TITLE
feat: integrate bedrock translation step

### DIFF
--- a/app.py
+++ b/app.py
@@ -420,11 +420,28 @@ def task_result(task_id, job_id):
     docx_path = os.path.join(job_dir, "result.docx")
     if not os.path.exists(docx_path):
         return "Job not found or failed.", 404
+    translations = []
+    log_json = os.path.join(job_dir, "log.json")
+    if os.path.exists(log_json):
+        try:
+            with open(log_json, "r", encoding="utf-8") as f:
+                steps = json.load(f)
+            for st in steps:
+                if st.get("type") == "translate_to_english" and st.get("output_md"):
+                    fname = os.path.basename(st["output_md"])
+                    if os.path.exists(os.path.join(job_dir, fname)):
+                        translations.append({
+                            "name": fname,
+                            "url": url_for("task_download", task_id=task_id, job_id=job_id, kind=fname),
+                        })
+        except Exception:
+            pass
     return render_template(
         "run.html",
         job_id=job_id,
         docx_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="docx"),
         log_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="log"),
+        translation_links=translations,
         back_link=url_for("flow_builder", task_id=task_id),
     )
 
@@ -445,6 +462,10 @@ def task_download(task_id, job_id, kind):
             as_attachment=True,
             download_name=f"log_{job_id}.json",
         )
+    else:
+        file_path = os.path.join(job_dir, kind)
+        if os.path.isfile(file_path):
+            return send_file(file_path, as_attachment=True, download_name=kind)
     abort(404)
 
 

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -10,6 +10,7 @@ from .Extract_AllFile_to_FinalWord import (
     extract_word_all_content,
     extract_word_chapter
 )
+from .translate_with_bedrock import translate_file as bedrock_translate_file
 
 SUPPORTED_STEPS = {
     "extract_pdf_chapter_to_table": {
@@ -26,6 +27,11 @@ SUPPORTED_STEPS = {
         "label": "擷取 Word 指定章節/標題",
         "inputs": ["input_file", "target_chapter_section", "target_title", "target_title_section"],
         "accepts": {"input_file": "file:docx", "target_chapter_section": "text", "target_title": "bool", "target_title_section": "text"}
+    },
+    "translate_to_english": {
+        "label": "翻譯文件至英文",
+        "inputs": ["input_file", "model_id"],
+        "accepts": {"input_file": "file:docx", "model_id": "text"}
     },
     "insert_text": {
         "label": "插入純文字段落",
@@ -92,6 +98,16 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     output_doc=output_doc,
                     section=section
                 )
+
+            elif stype == "translate_to_english":
+                infile = params["input_file"]
+                model_id = params.get("model_id")
+                out_md = os.path.join(
+                    workdir,
+                    os.path.splitext(os.path.basename(infile))[0] + "_translated.md",
+                )
+                bedrock_translate_file(infile, out_md, model_id=model_id)
+                log[-1]["output_md"] = out_md
 
             elif stype == "insert_text":
                 insert_text(section,

--- a/templates/run.html
+++ b/templates/run.html
@@ -5,6 +5,9 @@
 <div class="vstack gap-2">
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
+  {% for t in translation_links %}
+  <a class="btn btn-outline-primary" href="{{ t.url }}">下載翻譯 {{ t.name }}</a>
+  {% endfor %}
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- add Bedrock-powered translate_to_english workflow step
- surface generated Markdown translations in job results page

## Testing
- `python -m py_compile app.py modules/workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a461607190832382b0a9b53a4a4e17