### PR TITLE
Add on-demand translation download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Werkzeug==3.0.1
 python-docx==1.1.2
 PyMuPDF==1.24.8
 spire.doc==12.1.0
+boto3

--- a/templates/run.html
+++ b/templates/run.html
@@ -4,6 +4,7 @@
 <p class="mb-3">Job ID: <code>{{ job_id }}</code></p>
 <div class="vstack gap-2">
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
+  <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>


### PR DESCRIPTION
## Summary
- allow downloading a translated DOCX generated with Amazon Bedrock on demand
- add boto3 dependency

## Testing
- `python -m py_compile app.py modules/translate_with_bedrock.py modules/workflow.py`
- `pip install --quiet -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a466022cdc8323a39b3c6a3cee00c3