### PR TITLE
feat: add source comparison view

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row">
+  <div class="col-6" id="output-panel">
+    {% for sec in sections %}
+    <div class="mb-4">
+      <h5><a href="#" class="heading" data-index="{{ loop.index0 }}">{{ sec.roman }}. {{ sec.title }}</a></h5>
+      {% for p in sec.content %}
+      <p>{{ p }}</p>
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+  <div class="col-6" id="source-panel">
+    <p>請選擇左邊章節以查看來源內容</p>
+  </div>
+</div>
+<script>
+const sections = {{ sections|tojson }};
+function escapeHtml(str){
+  return str.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+}
+for(const el of document.querySelectorAll('.heading')){
+  el.addEventListener('click', function(e){
+    e.preventDefault();
+    const idx = this.dataset.index;
+    const sec = sections[idx];
+    const srcDiv = document.getElementById('source-panel');
+    let html = '';
+    if(sec.sources.length === 0){
+      html = '<p>無來源檔案</p>';
+    } else {
+      for(const s of sec.sources){
+        html += '<h6>'+escapeHtml(s.name)+'</h6>';
+        html += '<pre class="border p-2">'+escapeHtml(s.text)+'</pre>';
+      }
+    }
+    srcDiv.innerHTML = html;
+  });
+}
+</script>
+{% endblock %}

--- a/templates/run.html
+++ b/templates/run.html
@@ -6,6 +6,7 @@
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
+  <a class="btn btn-outline-primary" href="{{ compare_path }}">來源對照</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- add comparison page to view output alongside its source files
- link result page to the new comparison view

## Testing
- `python -m py_compile app.py modules/*.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a5ae8e63dc8323bba33a3d746cebbf