### PR TITLE
feat: add source comparison view

### DIFF
--- a/app.py
+++ b/app.py
@@ -428,7 +428,208 @@ def task_result(task_id, job_id):
         log_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="log"),
         translate_path=url_for("task_translate", task_id=task_id, job_id=job_id),
         back_link=url_for("flow_builder", task_id=task_id),
+        compare_path=url_for("task_compare", task_id=task_id, job_id=job_id),
     )
+
+
+@app.get("/tasks/<task_id>/compare/<job_id>")
+def task_compare(task_id, job_id):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    job_dir = os.path.join(tdir, "jobs", job_id)
+    docx_path = os.path.join(job_dir, "result.docx")
+    log_path = os.path.join(job_dir, "log.json")
+    if not os.path.exists(docx_path) or not os.path.exists(log_path):
+        abort(404)
+
+    with open(log_path, "r", encoding="utf-8") as f:
+        log = json.load(f)
+
+    headings = []
+    sources_map = {}
+    current = None
+
+    # Helpers to read specific snippets from source files
+    import docx
+    import re
+    import base64
+    from docx.oxml.table import CT_Tbl
+    from docx.oxml.text.paragraph import CT_P
+    from docx.text.paragraph import Paragraph
+    from docx.table import Table
+    from docx.oxml.ns import qn
+
+    def read_docx_text(path: str) -> str:
+        d = docx.Document(path)
+        return "\n".join(p.text for p in d.paragraphs if p.text.strip())
+
+    def extract_word_chapter_text(path: str, target: str, use_title: bool, title_section: str) -> str:
+        pattern = re.compile(rf"^\s*{re.escape(title_section if use_title else target)}(\s|$)", re.IGNORECASE)
+        stop_prefix = target.rsplit('.', 1)[0]
+        stop_pattern = re.compile(rf"^\s*{re.escape(stop_prefix)}(\.\d+)?(\s|$)", re.IGNORECASE)
+        doc = docx.Document(path)
+        capture = False
+        lines = []
+        for p in doc.paragraphs:
+            txt = p.text.strip()
+            if not txt:
+                continue
+            if pattern.match(txt):
+                capture = True
+            elif capture and stop_pattern.match(txt):
+                break
+            if capture:
+                lines.append(txt)
+        return "\n".join(lines)
+
+    def extract_pdf_snippets(folder: str, target: str) -> dict:
+        import fitz
+        results = {}
+        upper_ratio = 0.1
+        lower_ratio = 0.9
+        stop_pattern = re.compile(
+            r"^\s*(?:\d+\.\d+\.\d+|\d+\.\d+|[A-Z]\.|圖\s*\d+|Fig\.?\s*\d+|Figure\s+\d+)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        section_pattern = re.compile(rf"^\s*\d*\.?\s*{re.escape(target)}:?", re.IGNORECASE | re.MULTILINE)
+        english_pattern = re.compile(r'^[\x00-\x7F]+$')
+        for filename in os.listdir(folder):
+            if not filename.lower().endswith('.pdf'):
+                continue
+            pdf_path = os.path.join(folder, filename)
+            doc_pdf = fitz.open(pdf_path)
+            all_text = []
+            for page in doc_pdf:
+                width, height = page.rect.width, page.rect.height
+                capture_rect = fitz.Rect(0, height * upper_ratio, width, height * lower_ratio)
+                blocks = page.get_text("blocks", clip=capture_rect)
+                all_text.extend([b[4].strip() for b in blocks if b[4].strip()])
+            doc_pdf.close()
+            full_text = "\n".join(all_text)
+            capture_mode = False
+            section_lines = []
+            for line in full_text.splitlines():
+                if section_pattern.match(line):
+                    capture_mode = True
+                    if english_pattern.match(line):
+                        section_lines.append(line)
+                elif capture_mode and stop_pattern.match(line):
+                    break
+                elif capture_mode and english_pattern.match(line):
+                    section_lines.append(line)
+            extracted_text = " ".join(section_lines).strip()
+            if extracted_text:
+                match = re.search(r"(UOC|United)", extracted_text, re.IGNORECASE)
+                if match:
+                    extracted_text = extracted_text[:match.end()]
+                if not extracted_text.endswith('.'):
+                    extracted_text += '.'
+            else:
+                extracted_text = "（未找到英文內容）"
+            results[filename] = extracted_text
+        return results
+
+    # Build mapping of headings to their source snippets
+    for entry in log:
+        etype = entry.get("type")
+        params = entry.get("params", {})
+        if etype == "insert_roman_heading":
+            current = params.get("text", "")
+            headings.append(current)
+            sources_map[current] = []
+        elif current:
+            if etype == "extract_pdf_chapter_to_table":
+                folder = os.path.join(job_dir, "pdfs_extracted")
+                target = params.get("target_section", "")
+                snippets = extract_pdf_snippets(folder, target)
+                for name, text in snippets.items():
+                    sources_map[current].append({"name": name, "text": text})
+            elif etype == "extract_word_all_content":
+                src = params.get("input_file")
+                if src:
+                    sources_map[current].append({
+                        "name": os.path.basename(src),
+                        "text": read_docx_text(src),
+                    })
+            elif etype == "extract_word_chapter":
+                src = params.get("input_file")
+                if src:
+                    snippet = extract_word_chapter_text(
+                        src,
+                        params.get("target_chapter_section", ""),
+                        bool(params.get("target_title")),
+                        params.get("target_title_section", ""),
+                    )
+                    sources_map[current].append({
+                        "name": os.path.basename(src),
+                        "text": snippet,
+                    })
+            else:
+                for v in params.values():
+                    if isinstance(v, str) and os.path.isfile(v):
+                        sources_map[current].append({
+                            "name": os.path.basename(v),
+                            "text": read_docx_text(v),
+                        })
+
+    # Parse output document to collect paragraphs, images, and tables per section
+    doc = docx.Document(docx_path)
+    sections = []
+    current_title = None
+    content = []
+
+    def flush_section():
+        if current_title is not None:
+            sections.append({
+                "title": current_title,
+                "content": content[:],
+                "sources": sources_map.get(current_title, []),
+            })
+
+    for block in doc.element.body.iterchildren():
+        if isinstance(block, CT_P):
+            p = Paragraph(block, doc)
+            txt = p.text.strip()
+            if txt in headings:
+                flush_section()
+                current_title = txt
+                content = []
+                continue
+            # extract images inside paragraph
+            has_image = False
+            for r in p.runs:
+                for blip in r.element.xpath('.//a:blip'):
+                    rid = blip.attrib.get(qn('r:embed'))
+                    part = doc.part.related_parts[rid]
+                    b64 = base64.b64encode(part.blob).decode('ascii')
+                    content.append({"type": "image", "data": f"data:image/png;base64,{b64}"})
+                    has_image = True
+            if txt:
+                content.append({"type": "paragraph", "text": txt})
+        elif isinstance(block, CT_Tbl):
+            tbl = Table(block, doc)
+            rows = []
+            for row in tbl.rows:
+                rows.append([cell.text.strip() for cell in row.cells])
+            content.append({"type": "table", "rows": rows})
+
+    flush_section()
+
+    def to_roman(num: int) -> str:
+        vals = [
+            (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"),
+            (100, "C"), (90, "XC"), (50, "L"), (40, "XL"),
+            (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I"),
+        ]
+        res = ""
+        for v, s in vals:
+            res += s * (num // v)
+            num %= v
+        return res
+
+    for i, sec in enumerate(sections, start=1):
+        sec["roman"] = to_roman(i)
+
+    return render_template("compare.html", sections=sections)
 
 
 @app.get("/tasks/<task_id>/translate/<job_id>")

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row">
+  <div class="col-6" id="output-panel">
+    {% for sec in sections %}
+    <div class="mb-4">
+      <h5><a href="#" class="heading" data-index="{{ loop.index0 }}">{{ sec.roman }}. {{ sec.title }}</a></h5>
+      {% for item in sec.content %}
+      {% if item.type == 'paragraph' %}
+      <p>{{ item.text }}</p>
+      {% elif item.type == 'image' %}
+      <img src="{{ item.data }}" class="img-fluid d-block mx-auto my-2" />
+      {% elif item.type == 'table' %}
+      <table class="table table-bordered">
+        {% for row in item.rows %}
+        <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+        {% endfor %}
+      </table>
+      {% endif %}
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+  <div class="col-6" id="source-panel">
+    <p>請選擇左邊章節以查看來源內容</p>
+  </div>
+</div>
+<script>
+const sections = {{ sections|tojson }};
+function escapeHtml(str){
+  return str.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+}
+for(const el of document.querySelectorAll('.heading')){
+  el.addEventListener('click', function(e){
+    e.preventDefault();
+    const idx = this.dataset.index;
+    const sec = sections[idx];
+    const srcDiv = document.getElementById('source-panel');
+    let html = '';
+    if(sec.sources.length === 0){
+      html = '<p>無來源檔案</p>';
+    } else {
+      for(const s of sec.sources){
+        html += '<h6>'+escapeHtml(s.name)+'</h6>';
+        html += '<pre class="border p-2">'+escapeHtml(s.text)+'</pre>';
+      }
+    }
+    srcDiv.innerHTML = html;
+  });
+}
+</script>
+{% endblock %}

--- a/templates/run.html
+++ b/templates/run.html
@@ -6,6 +6,7 @@
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
+  <a class="btn btn-outline-primary" href="{{ compare_path }}">來源對照</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- show tables and images on comparison view output pane
- limit source display to extracted snippets, including per-PDF sections

## Testing
- `python -m py_compile app.py modules/*.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a5ae8e63dc8323bba33a3d746cebbf