### PR TITLE
Add comparison view for workflow results

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask import (
     redirect,
     url_for,
     send_file,
+    send_from_directory,
     abort,
 )
 from werkzeug.utils import secure_filename
@@ -427,6 +428,7 @@ def task_result(task_id, job_id):
         docx_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="docx"),
         log_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="log"),
         translate_path=url_for("task_translate", task_id=task_id, job_id=job_id),
+        compare_path=url_for("task_compare", task_id=task_id, job_id=job_id),
         back_link=url_for("flow_builder", task_id=task_id),
     )
 
@@ -453,6 +455,78 @@ def task_translate(task_id, job_id):
         as_attachment=True,
         download_name=f"translated_{job_id}.docx",
     )
+
+
+@app.get("/tasks/<task_id>/compare/<job_id>")
+def task_compare(task_id, job_id):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    job_dir = os.path.join(tdir, "jobs", job_id)
+    docx_path = os.path.join(job_dir, "result.docx")
+    log_path = os.path.join(job_dir, "log.json")
+    if not os.path.exists(docx_path) or not os.path.exists(log_path):
+        abort(404)
+
+    html_name = "result.html"
+    html_path = os.path.join(job_dir, html_name)
+    if not os.path.exists(html_path):
+        from spire.doc import Document, FileFormat
+        doc = Document()
+        doc.LoadFromFile(docx_path)
+        doc.SaveToFile(html_path, FileFormat.Html)
+        doc.Close()
+
+    chapter_sources = {}
+    current = None
+    with open(log_path, "r", encoding="utf-8") as f:
+        entries = json.load(f)
+    for entry in entries:
+        stype = entry.get("type")
+        params = entry.get("params", {})
+        if stype == "insert_roman_heading":
+            current = params.get("text", "")
+            chapter_sources.setdefault(current, [])
+        elif stype == "extract_pdf_chapter_to_table":
+            zip_path = params.get("pdf_zip", "")
+            pdfs = []
+            if zip_path and os.path.exists(zip_path):
+                import zipfile
+                with zipfile.ZipFile(zip_path, "r") as zf:
+                    pdfs = [os.path.basename(n) for n in zf.namelist() if not n.endswith("/")]
+            chapter_sources.setdefault(current or "未分類", []).extend(pdfs)
+        elif stype == "extract_word_chapter":
+            infile = os.path.basename(params.get("input_file", ""))
+            sec = params.get("target_chapter_section", "")
+            use_title = str(params.get("target_title", "")).lower() in ["1", "true", "yes", "on"]
+            title = params.get("target_title_section", "") if use_title else ""
+            info = infile
+            if sec:
+                info += f" 章節 {sec}"
+            if title:
+                info += f" 標題 {title}"
+            chapter_sources.setdefault(current or "未分類", []).append(info)
+        elif stype == "extract_word_all_content":
+            infile = os.path.basename(params.get("input_file", ""))
+            chapter_sources.setdefault(current or "未分類", []).append(infile)
+
+    chapters = list(chapter_sources.keys())
+    html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
+    return render_template(
+        "compare.html",
+        html_url=html_url,
+        chapters=chapters,
+        chapter_sources=chapter_sources,
+        back_link=url_for("task_result", task_id=task_id, job_id=job_id),
+    )
+
+
+@app.get("/tasks/<task_id>/view/<job_id>/<path:filename>")
+def task_view_file(task_id, job_id, filename):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    job_dir = os.path.join(tdir, "jobs", job_id)
+    file_path = os.path.join(job_dir, filename)
+    if not os.path.isfile(file_path):
+        abort(404)
+    return send_from_directory(job_dir, filename)
 
 
 @app.get("/tasks/<task_id>/download/<job_id>/<kind>")

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h4 mb-3">來源比對</h1>
+<div class="row g-3">
+  <div class="col-md-8">
+    <iframe src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">選擇章節</label>
+    <select id="chapterSelect" class="form-select mb-2">
+      {% for ch in chapters %}
+      <option value="{{ ch }}">{{ ch }}</option>
+      {% endfor %}
+    </select>
+    <ul id="sourceList" class="list-group"></ul>
+    <div class="mt-3">
+      <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
+    </div>
+  </div>
+</div>
+<script>
+const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
+function updateSources(ch){
+  const list = document.getElementById('sourceList');
+  list.innerHTML = '';
+  (CHAPTER_SOURCES[ch] || []).forEach(src => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = src;
+    list.appendChild(li);
+  });
+}
+const select = document.getElementById('chapterSelect');
+select.addEventListener('change', () => updateSources(select.value));
+if (select.value){ updateSources(select.value); }
+</script>
+{% endblock %}

--- a/templates/run.html
+++ b/templates/run.html
@@ -6,6 +6,7 @@
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
+  <a class="btn btn-outline-primary" href="{{ compare_path }}">來源比對</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- Add compare page showing generated document on the left and source references by chapter on the right
- Serve converted HTML resources from job directory and link to comparison from result page
- Import missing `send_from_directory` to prevent runtime errors when viewing files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee2879948323a45e344a8bfa5927