### PR TITLE
Add comparison view for workflow results

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h4 mb-3">來源比對</h1>
+<div class="row g-3">
+  <div class="col-md-8">
+    <iframe id="docFrame" style="width:100%; height:80vh;" class="border"></iframe>
+  </div>
+  <div class="col-md-4">
+    <p class="text-muted">點擊左側標題顯示來源</p>
+    <ul id="sourceList" class="list-group"></ul>
+    <div class="mt-3">
+      <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
+    </div>
+  </div>
+</div>
+<script>
+const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
+const HTML_URL = {{ html_url|tojson }};
+const BASE_URL = {{ base_url|tojson }};
+const FRAME = document.getElementById('docFrame');
+FRAME.addEventListener('load', () => {
+  const doc = FRAME.contentDocument;
+  doc.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach(el => {
+    const text = el.textContent.trim();
+    const m = text.match(/^([IVXLCDM]+)[\s\.．、\)]/);
+    if (m) {
+      el.style.cursor = 'pointer';
+      el.addEventListener('click', () => updateSources(m[1]));
+    }
+  });
+});
+fetch(HTML_URL).then(r => r.text()).then(html => {
+  FRAME.srcdoc = `<base href="${BASE_URL}">` + html;
+});
+function updateSources(ch){
+  const list = document.getElementById('sourceList');
+  list.innerHTML = '';
+  (CHAPTER_SOURCES[ch] || []).forEach(src => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = src;
+    list.appendChild(li);
+  });
+}
+</script>
+{% endblock %}

--- a/templates/run.html
+++ b/templates/run.html
@@ -6,6 +6,7 @@
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
+  <a class="btn btn-outline-primary" href="{{ compare_path }}">來源比對</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- Map log entries by Roman numeral prefix so chapter clicks in the comparison view show sources
- Detect Roman numeral prefixes in the HTML and pass only the numeral to the source-list lookup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5ee2879948323a45e344a8bfa5927