### PR TITLE
Enable chapter source selection via clickable headings

### DIFF
--- a/app.py
+++ b/app.py
@@ -508,12 +508,10 @@ def task_compare(task_id, job_id):
             infile = os.path.basename(params.get("input_file", ""))
             chapter_sources.setdefault(current or "未分類", []).append(infile)
 
-    chapters = list(chapter_sources.keys())
     html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
     return render_template(
         "compare.html",
         html_url=html_url,
-        chapters=chapters,
         chapter_sources=chapter_sources,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
     )

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -6,12 +6,7 @@
     <iframe src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
   </div>
   <div class="col-md-4">
-    <label class="form-label">選擇章節</label>
-    <select id="chapterSelect" class="form-select mb-2">
-      {% for ch in chapters %}
-      <option value="{{ ch }}">{{ ch }}</option>
-      {% endfor %}
-    </select>
+    <p class="form-text">請點擊輸出內容中的章節標題以檢視來源</p>
     <ul id="sourceList" class="list-group"></ul>
     <div class="mt-3">
       <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
@@ -30,8 +25,19 @@ function updateSources(ch){
     list.appendChild(li);
   });
 }
-const select = document.getElementById('chapterSelect');
-select.addEventListener('change', () => updateSources(select.value));
-if (select.value){ updateSources(select.value); }
+const iframe = document.querySelector('iframe');
+iframe.addEventListener('load', () => {
+  const doc = iframe.contentDocument;
+  const headings = doc.querySelectorAll('h1,h2,h3,h4,h5,h6,p');
+  headings.forEach(h => {
+    const text = h.textContent.trim();
+    Object.keys(CHAPTER_SOURCES).forEach(ch => {
+      if (text === ch || text.startsWith(ch + ' ') || text.startsWith(ch + '.')) {
+        h.style.cursor = 'pointer';
+        h.addEventListener('click', () => updateSources(ch));
+      }
+    });
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace chapter dropdown in compare view with instruction text
- Allow clicking roman numeral headings in output to list their sources
- Simplify compare route to omit unused chapter list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5fea39b60832396ab422a1e3718ae