### PR TITLE
Normalize heading text and regex chapter matching

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -30,9 +30,10 @@ iframe.addEventListener('load', () => {
   const doc = iframe.contentDocument;
   const headings = doc.querySelectorAll('h1,h2,h3,h4,h5,h6,p');
   headings.forEach(h => {
-    const text = h.textContent.trim();
+    const text = h.textContent.replace(/\u00A0/g, ' ').trim();
     Object.keys(CHAPTER_SOURCES).forEach(ch => {
-      if (text === ch || text.startsWith(ch + ' ') || text.startsWith(ch + '.')) {
+      const regex = new RegExp(`^${ch}\\b\\W*`);
+      if (regex.test(text)) {
         h.style.cursor = 'pointer';
         h.addEventListener('click', () => updateSources(ch));
       }


### PR DESCRIPTION
## Summary
- Normalize heading text by removing non-breaking spaces before matching
- Replace direct chapter string checks with regex matching leading Roman numerals, ignoring punctuation or extra spaces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a600a1af648323abef25a1d6bd8229