### PR TITLE
Handle uncategorized sources in compare view

### DIFF
--- a/app.py
+++ b/app.py
@@ -484,7 +484,7 @@ def task_compare(task_id, job_id):
         params = entry.get("params", {})
         if stype == "insert_roman_heading":
             current = params.get("text", "")
-            chapter_sources.setdefault(current, [])
+            chapter_sources.setdefault(current or "未分類", [])
         elif stype == "extract_pdf_chapter_to_table":
             zip_path = params.get("pdf_zip", "")
             pdfs = []

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -6,7 +6,12 @@
     <iframe src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
   </div>
   <div class="col-md-4">
-    <p class="form-text">請點擊輸出內容中的章節標題以檢視來源</p>
+    <p class="form-text">
+      請點擊輸出內容中的章節標題以檢視來源
+      {% if "未分類" in chapter_sources %}
+      <br><a href="#" id="showUnclassified">未分類來源</a>
+      {% endif %}
+    </p>
     <ul id="sourceList" class="list-group"></ul>
     <div class="mt-3">
       <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
@@ -25,6 +30,8 @@
 </style>
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
+const UNCLASSIFIED = "未分類";
+const chapterKeys = Object.keys(CHAPTER_SOURCES);
 function updateSources(ch){
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
@@ -35,7 +42,7 @@ function updateSources(ch){
     list.appendChild(li);
   });
 }
-const firstChapter = Object.keys(CHAPTER_SOURCES)[0];
+const firstChapter = chapterKeys.includes(UNCLASSIFIED) ? UNCLASSIFIED : chapterKeys[0];
 if (firstChapter) {
   updateSources(firstChapter);
 }
@@ -45,7 +52,8 @@ iframe.addEventListener('load', () => {
   const headings = doc.querySelectorAll('h1,h2,h3,h4,h5,h6,p');
   headings.forEach(h => {
     const text = h.textContent.replace(/\u00A0/g, ' ').trim();
-    Object.keys(CHAPTER_SOURCES).forEach(ch => {
+    chapterKeys.forEach(ch => {
+      if (ch === UNCLASSIFIED) return;
       const regex = new RegExp(`^${ch}\\b\\W*`);
       if (regex.test(text)) {
         h.classList.add('clickable-heading');
@@ -55,5 +63,11 @@ iframe.addEventListener('load', () => {
     });
   });
 });
+if (CHAPTER_SOURCES[UNCLASSIFIED]) {
+  document.getElementById('showUnclassified')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    updateSources(UNCLASSIFIED);
+  });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Avoid blank keys in chapter sources by defaulting to "未分類" when headings are missing
- Add UI and script support to show "未分類" sources in compare view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a602946e9c8323b5334096cd126ba5