### PR TITLE
Add source comparison viewer

### DIFF
--- a/app.py
+++ b/app.py
@@ -421,9 +421,71 @@ def task_result(task_id, job_id):
     docx_path = os.path.join(job_dir, "result.docx")
     if not os.path.exists(docx_path):
         return "Job not found or failed.", 404
+    # Load log for source mapping
+    log_file = os.path.join(job_dir, "log.json")
+    log_data = {"steps": [], "sections": []}
+    if os.path.exists(log_file):
+        with open(log_file, "r", encoding="utf-8") as f:
+            try:
+                log_data = json.load(f)
+            except Exception:
+                pass
+    steps = log_data.get("steps", log_data if isinstance(log_data, list) else [])
+
+    # Convert docx to HTML with inline images
+    import mammoth, re
+
+    with open(docx_path, "rb") as f:
+        html = mammoth.convert_to_html(f, convert_image=mammoth.images.inline()).value
+
+    # Mark Roman numeral headings
+    heading_re = re.compile(r'<p>(\s*(?P<num>[IVXLCDM]+)\.[^<]*)</p>')
+
+    def repl(m):
+        num = m.group("num")
+        return f'<p class="doc-heading" data-section="{num}">{m.group(1)}</p>'
+
+    html = heading_re.sub(repl, html)
+
+    # Build mapping from section to source info
+    def boolish(v: str) -> bool:
+        return str(v).lower() in ["1", "true", "yes", "y", "on"]
+
+    sources = {}
+    for step in steps:
+        section = step.get("section")
+        if not section:
+            continue
+        stype = step.get("type")
+        params = step.get("params", {})
+        if stype == "extract_pdf_chapter_to_table":
+            pdf_dir = os.path.join(job_dir, f"pdfs_extracted_{step.get('step')}")
+            files = []
+            if os.path.isdir(pdf_dir):
+                files = sorted([fn for fn in os.listdir(pdf_dir) if fn.lower().endswith(".pdf")])
+            info = {"kind": "pdf", "files": files}
+        elif stype == "extract_word_chapter":
+            info = {
+                "kind": "word_chapter",
+                "file": os.path.basename(params.get("input_file", "")),
+                "chapter": params.get("target_chapter_section", ""),
+            }
+            if boolish(params.get("target_title", "false")):
+                info["title"] = params.get("target_title_section", "")
+        elif stype == "extract_word_all_content":
+            info = {
+                "kind": "word_all",
+                "file": os.path.basename(params.get("input_file", "")),
+            }
+        else:
+            continue
+        sources.setdefault(section, []).append(info)
+
     return render_template(
         "run.html",
         job_id=job_id,
+        content_html=html,
+        sources=sources,
         docx_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="docx"),
         log_path=url_for("task_download", task_id=task_id, job_id=job_id, kind="log"),
         translate_path=url_for("task_translate", task_id=task_id, job_id=job_id),

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -1,5 +1,6 @@
 
 import os
+import json
 from typing import List, Dict, Any
 from spire.doc import *
 from spire.doc.common import *
@@ -52,15 +53,47 @@ SUPPORTED_STEPS = {
 def boolish(v:str)->bool:
     return str(v).lower() in ["1","true","yes","y","on"]
 
-def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
+def _int_to_roman(num: int) -> str:
+    vals = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1]
+    syms = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"]
+    res = ""
+    for v, s in zip(vals, syms):
+        while num >= v:
+            res += s
+            num -= v
+    return res
+
+
+def run_workflow(steps: List[Dict[str, Any]], workdir: str) -> Dict[str, Any]:
     log = []
+    sections_info = []
+    current_section = None
+    roman_idx = 0
+
     output_doc = Document()
     section = output_doc.AddSection()
 
     for idx, step in enumerate(steps, start=1):
         stype = step.get("type")
         params = step.get("params", {})
-        log.append({"step": idx, "type": stype, "params": params})
+
+        # heading bookkeeping
+        if stype == "insert_roman_heading":
+            roman_idx += 1
+            current_section = _int_to_roman(roman_idx)
+            sections_info.append({
+                "index": roman_idx,
+                "numeral": current_section,
+                "text": params.get("text", "")
+            })
+            entry = {"step": idx, "type": stype, "params": params, "section": current_section}
+        else:
+            entry = {"step": idx, "type": stype, "params": params}
+            if stype in ["extract_pdf_chapter_to_table", "extract_word_all_content", "extract_word_chapter"]:
+                entry["section"] = current_section
+
+        log.append(entry)
+
         try:
             if stype == "extract_pdf_chapter_to_table":
                 import zipfile
@@ -68,7 +101,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                 target = params["target_section"]
                 if not zip_path or not os.path.isfile(zip_path):
                     raise RuntimeError("未提供 PDF ZIP 檔或路徑錯誤")
-                extract_dir = os.path.join(workdir, "pdfs_extracted")
+                extract_dir = os.path.join(workdir, f"pdfs_extracted_{idx}")
                 os.makedirs(extract_dir, exist_ok=True)
                 with zipfile.ZipFile(zip_path, 'r') as zf:
                     zf.extractall(extract_dir)
@@ -76,54 +109,67 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
 
             elif stype == "extract_word_all_content":
                 infile = params["input_file"]
-                extract_word_all_content(infile, output_image_path=os.path.join(workdir,"images"), output_doc=output_doc, section=section)
+                extract_word_all_content(
+                    infile,
+                    output_image_path=os.path.join(workdir, "images"),
+                    output_doc=output_doc,
+                    section=section,
+                )
 
             elif stype == "extract_word_chapter":
                 infile = params["input_file"]
-                tsec = params.get("target_chapter_section","")
-                use_title = boolish(params.get("target_title","false"))
-                title_text = params.get("target_title_section","")
+                tsec = params.get("target_chapter_section", "")
+                use_title = boolish(params.get("target_title", "false"))
+                title_text = params.get("target_title_section", "")
                 extract_word_chapter(
                     infile,
                     tsec,
                     target_title=use_title,
                     target_title_section=title_text,
-                    output_image_path=os.path.join(workdir,"images"),
+                    output_image_path=os.path.join(workdir, "images"),
                     output_doc=output_doc,
-                    section=section
+                    section=section,
                 )
 
             elif stype == "insert_text":
-                insert_text(section,
-                            params.get("text",""),
-                            align=params.get("align","left"),
-                            bold=boolish(params.get("bold","false")),
-                            font_size=float(params.get("font_size",12)),
-                            before_space=float(params.get("before_space",0)),
-                            after_space=float(params.get("after_space",6)),
-                            page_break_before=boolish(params.get("page_break_before","false")))
+                insert_text(
+                    section,
+                    params.get("text", ""),
+                    align=params.get("align", "left"),
+                    bold=boolish(params.get("bold", "false")),
+                    font_size=float(params.get("font_size", 12)),
+                    before_space=float(params.get("before_space", 0)),
+                    after_space=float(params.get("after_space", 6)),
+                    page_break_before=boolish(params.get("page_break_before", "false")),
+                )
 
             elif stype == "insert_numbered_heading":
-                insert_numbered_heading(section,
-                                        params.get("text",""),
-                                        level=int(params.get("level",0)),
-                                        bold=boolish(params.get("bold","true")),
-                                        font_size=float(params.get("font_size",14)))
+                insert_numbered_heading(
+                    section,
+                    params.get("text", ""),
+                    level=int(params.get("level", 0)),
+                    bold=boolish(params.get("bold", "true")),
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             elif stype == "insert_roman_heading":
-                insert_roman_heading(section,
-                                     params.get("text",""),
-                                     level=int(params.get("level",0)),
-                                     bold=boolish(params.get("bold","true")),
-                                     font_size=float(params.get("font_size",14)))
+                insert_roman_heading(
+                    section,
+                    params.get("text", ""),
+                    level=int(params.get("level", 0)),
+                    bold=boolish(params.get("bold", "true")),
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             elif stype == "insert_bulleted_heading":
-                insert_bulleted_heading(section,
-                                        params.get("text",""),
-                                        level=0,
-                                        bullet_char='•',
-                                        bold=True,
-                                        font_size=float(params.get("font_size",14)))
+                insert_bulleted_heading(
+                    section,
+                    params.get("text", ""),
+                    level=0,
+                    bullet_char='•',
+                    bold=True,
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             else:
                 raise RuntimeError(f"Unknown step type: {stype}")
@@ -139,8 +185,8 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
     output_doc.Close()
 
     out_log = os.path.join(workdir, "log.json")
+    data = {"steps": log, "sections": sections_info}
     with open(out_log, "w", encoding="utf-8") as f:
-        import json
-        json.dump(log, f, ensure_ascii=False, indent=2)
+        json.dump(data, f, ensure_ascii=False, indent=2)
 
-    return {"result_docx": out_docx, "log": out_log, "log_json": log}
+    return {"result_docx": out_docx, "log": out_log, "log_json": data}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-docx==1.1.2
 PyMuPDF==1.24.8
 spire.doc==12.1.0
 boto3
+mammoth==1.6.0

--- a/templates/run.html
+++ b/templates/run.html
@@ -2,13 +2,45 @@
 {% block content %}
 <h1 class="h4">流程已完成</h1>
 <p class="mb-3">Job ID: <code>{{ job_id }}</code></p>
-<div class="vstack gap-2">
+<div class="mb-3 d-flex flex-wrap gap-2">
   <a class="btn btn-primary" href="{{ docx_path }}">下載結果 DOCX</a>
   <a class="btn btn-primary" href="{{ translate_path }}">下載翻譯 DOCX</a>
   <a class="btn btn-outline-secondary" href="{{ log_path }}">下載流程 Log</a>
   {% if back_link %}
   <a class="btn btn-secondary" href="{{ back_link }}">返回流程</a>
   {% endif %}
-  <a class="btn btn-link" href="{{ url_for('tasks') }}">回首頁</a>
 </div>
+<div class="row">
+  <div class="col-md-6 border-end" id="doc-content">
+    {{ content_html|safe }}
+  </div>
+  <div class="col-md-6" id="source-panel">
+    <p class="text-muted">請點選左側章節以檢視來源</p>
+  </div>
+</div>
+<script>
+const sources = {{ sources|tojson }};
+document.querySelectorAll('#doc-content .doc-heading').forEach(el => {
+  el.style.cursor = 'pointer';
+  el.addEventListener('click', () => {
+    const key = el.dataset.section;
+    const panel = document.getElementById('source-panel');
+    panel.innerHTML = '';
+    (sources[key] || []).forEach(item => {
+      const div = document.createElement('div');
+      if (item.kind === 'pdf') {
+        div.innerHTML = '<h5>PDF 檔案</h5><ul>' + item.files.map(function(f){return '<li>' + f + '</li>';}).join('') + '</ul>';
+      } else if (item.kind === 'word_chapter') {
+        div.innerHTML = '<p>檔案: ' + item.file + '</p><p>章節: ' + item.chapter + '</p>' + (item.title ? '<p>標題: ' + item.title + '</p>' : '');
+      } else if (item.kind === 'word_all') {
+        div.innerHTML = '<p>檔案: ' + item.file + '</p>';
+      }
+      panel.appendChild(div);
+    });
+    if (panel.innerHTML === '') {
+      panel.innerHTML = '<p class="text-muted">無來源資料</p>';
+    }
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- convert workflow result into inline HTML and build section-to-source mappings
- track Roman numeral headings and per-step source info during workflow execution
- render run results in a side-by-side viewer with interactive source display

## Testing
- `pip install mammoth` *(fails: Could not connect to proxy)*
- `python -m py_compile app.py modules/workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a606efd49c83238e046a62a08b0c41