### PR TITLE
Enable chapter click to show sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -508,12 +508,10 @@ def task_compare(task_id, job_id):
             infile = os.path.basename(params.get("input_file", ""))
             chapter_sources.setdefault(current or "未分類", []).append(infile)
 
-    chapters = list(chapter_sources.keys())
     html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
     return render_template(
         "compare.html",
         html_url=html_url,
-        chapters=chapters,
         chapter_sources=chapter_sources,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
     )

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -3,15 +3,10 @@
 <h1 class="h4 mb-3">來源比對</h1>
 <div class="row g-3">
   <div class="col-md-8">
-    <iframe src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
+    <iframe id="resultFrame" src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
   </div>
   <div class="col-md-4">
-    <label class="form-label">選擇章節</label>
-    <select id="chapterSelect" class="form-select mb-2">
-      {% for ch in chapters %}
-      <option value="{{ ch }}">{{ ch }}</option>
-      {% endfor %}
-    </select>
+    <p class="form-label">點擊左側章節以查看來源</p>
     <ul id="sourceList" class="list-group"></ul>
     <div class="mt-3">
       <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
@@ -30,8 +25,23 @@ function updateSources(ch){
     list.appendChild(li);
   });
 }
-const select = document.getElementById('chapterSelect');
-select.addEventListener('change', () => updateSources(select.value));
-if (select.value){ updateSources(select.value); }
+function normalize(text){
+  return text.replace(/^\s*[IVXLCDM]+\.\s*/i, '').trim();
+}
+function setupFrame(){
+  const frame = document.getElementById('resultFrame');
+  const doc = frame.contentDocument;
+  if(!doc) return;
+  const map = {};
+  Object.keys(CHAPTER_SOURCES).forEach(k => { map[normalize(k)] = k; });
+  doc.querySelectorAll('p,h1,h2,h3,h4,h5,h6').forEach(el => {
+    const key = map[normalize(el.innerText)];
+    if(key){
+      el.style.cursor = 'pointer';
+      el.addEventListener('click', () => updateSources(key));
+    }
+  });
+}
+document.getElementById('resultFrame').addEventListener('load', setupFrame);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow clicking roman-numeral chapter headings in the comparison view to show sources
- Remove dropdown selection and attach event handlers directly inside result document

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60af9f80c832386d4d19d553b70e7