### PR TITLE
Enable clickable chapters for source comparison

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -3,15 +3,9 @@
 <h1 class="h4 mb-3">來源比對</h1>
 <div class="row g-3">
   <div class="col-md-8">
-    <iframe src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
+    <iframe id="htmlFrame" src="{{ html_url }}" style="width:100%; height:80vh;" class="border"></iframe>
   </div>
   <div class="col-md-4">
-    <label class="form-label">選擇章節</label>
-    <select id="chapterSelect" class="form-select mb-2">
-      {% for ch in chapters %}
-      <option value="{{ ch }}">{{ ch }}</option>
-      {% endfor %}
-    </select>
     <ul id="sourceList" class="list-group"></ul>
     <div class="mt-3">
       <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
@@ -20,6 +14,7 @@
 </div>
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
+const CHAPTERS = {{ chapters|tojson }};
 function updateSources(ch){
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
@@ -30,8 +25,16 @@ function updateSources(ch){
     list.appendChild(li);
   });
 }
-const select = document.getElementById('chapterSelect');
-select.addEventListener('change', () => updateSources(select.value));
-if (select.value){ updateSources(select.value); }
+const iframe = document.getElementById('htmlFrame');
+iframe.addEventListener('load', () => {
+  const doc = iframe.contentDocument || iframe.contentWindow.document;
+  CHAPTERS.forEach(ch => {
+    const elements = Array.from(doc.body.querySelectorAll('*')).filter(el => el.textContent.trim() === ch);
+    elements.forEach(el => {
+      el.style.cursor = 'pointer';
+      el.addEventListener('click', () => updateSources(ch));
+    });
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow clicking chapters directly in the HTML preview to view source files
- Remove chapter dropdown in source comparison page

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a67de628c083239224ecaed82a803f