### PR TITLE
feat: color-coded source highlight

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -15,7 +15,18 @@
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
-function updateSources(ch){
+const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
+let highlighted = [];
+
+function clearHighlights() {
+  highlighted.forEach(el => {
+    el.style.backgroundColor = '';
+  });
+  highlighted = [];
+}
+
+function updateSources(ch, element) {
+  clearHighlights();
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
   let sources = [];
@@ -27,12 +38,28 @@ function updateSources(ch){
   } else {
     sources = CHAPTER_SOURCES[ch] || [];
   }
-  sources.forEach(src => {
+  const colorMap = {};
+  sources.forEach((src, idx) => {
+    const color = COLORS[idx % COLORS.length];
+    colorMap[src] = color;
     const li = document.createElement('li');
     li.className = 'list-group-item';
     li.textContent = src;
+    li.style.backgroundColor = color;
     list.appendChild(li);
   });
+  if (element && sources.length) {
+    let node = element.nextElementSibling;
+    let idx = 0;
+    while (node && !/^H[1-6]$/.test(node.tagName)) {
+      const src = sources[idx % sources.length];
+      const color = colorMap[src];
+      node.style.backgroundColor = color;
+      highlighted.push(node);
+      node = node.nextElementSibling;
+      idx++;
+    }
+  }
 }
 
 const iframe = document.getElementById('htmlFrame');
@@ -46,7 +73,7 @@ iframe.addEventListener('load', () => {
       found = true;
       elements.forEach(el => {
         el.style.cursor = 'pointer';
-        el.addEventListener('click', () => updateSources(ch));
+        el.addEventListener('click', () => updateSources(ch, el));
       });
     } else {
       unhandled = unhandled.concat(CHAPTER_SOURCES[ch] || []);


### PR DESCRIPTION
## Summary
- color-code source list and HTML segments on source comparison page
- clear previous highlights when switching chapters

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0984780832388ffef77dfab79ef