### PR TITLE
fix: color segments by source

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -15,24 +15,84 @@
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
-function updateSources(ch){
+const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
+const CHAPTER_SET = new Set(CHAPTERS);
+let highlighted = [];
+
+function clearHighlights() {
+  highlighted.forEach(el => {
+    el.style.backgroundColor = '';
+  });
+  highlighted = [];
+}
+
+function updateSources(ch, element) {
+  clearHighlights();
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
-  let sources = [];
+  let sequence = [];
   if (Array.isArray(ch)) {
-    sources = [...new Set(ch)];
+    sequence = ch.slice();
   } else if (ch === null) {
     const all = Object.values(CHAPTER_SOURCES).flat();
-    sources = [...new Set(all)];
+    sequence = all.slice();
   } else {
-    sources = CHAPTER_SOURCES[ch] || [];
+    sequence = CHAPTER_SOURCES[ch] || [];
   }
-  sources.forEach(src => {
+  if (!sequence.length) return;
+
+  const uniqueSources = [...new Set(sequence)];
+  const colorMap = {};
+  let colorIdx = 0;
+  let pdfColor = null;
+  uniqueSources.forEach(src => {
+    let color;
+    if (src.toLowerCase().endsWith('.pdf')) {
+      if (!pdfColor) {
+        pdfColor = COLORS[colorIdx % COLORS.length];
+        colorIdx++;
+      }
+      color = pdfColor;
+    } else {
+      color = COLORS[colorIdx % COLORS.length];
+      colorIdx++;
+    }
+    colorMap[src] = color;
     const li = document.createElement('li');
     li.className = 'list-group-item';
     li.textContent = src;
+    li.style.backgroundColor = color;
     list.appendChild(li);
   });
+
+  if (element) {
+    let node = element.nextElementSibling;
+    let idx = 0;
+    const sections = sequence.map(src => {
+      const m = src.match(/章節\s*([\d\.]+)/);
+      return m ? m[1] : null;
+    });
+    const findNextSectionIdx = from => {
+      for (let i = from + 1; i < sections.length; i++) {
+        if (sections[i]) return i;
+      }
+      return -1;
+    };
+    let nextIdx = findNextSectionIdx(0);
+    let nextSection = nextIdx !== -1 ? sections[nextIdx] : null;
+    while (node && !CHAPTER_SET.has(node.textContent.trim())) {
+      const text = node.textContent.trim();
+      if (nextSection && text.startsWith(nextSection)) {
+        idx = nextIdx;
+        nextIdx = findNextSectionIdx(idx);
+        nextSection = nextIdx !== -1 ? sections[nextIdx] : null;
+      }
+      const src = sequence[idx] || sequence[sequence.length - 1];
+      node.style.backgroundColor = colorMap[src];
+      highlighted.push(node);
+      node = node.nextElementSibling;
+    }
+  }
 }
 
 const iframe = document.getElementById('htmlFrame');
@@ -46,7 +106,7 @@ iframe.addEventListener('load', () => {
       found = true;
       elements.forEach(el => {
         el.style.cursor = 'pointer';
-        el.addEventListener('click', () => updateSources(ch));
+        el.addEventListener('click', () => updateSources(ch, el));
       });
     } else {
       unhandled = unhandled.concat(CHAPTER_SOURCES[ch] || []);


### PR DESCRIPTION
## Summary
- highlight chapter sections using source-based colors
- group ZIP-extracted PDFs under a single highlight

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0984780832388ffef77dfab79ef