### PR TITLE
fix: color segments by source

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -15,24 +15,94 @@
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
-function updateSources(ch){
+const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
+const CHAPTER_SET = new Set(CHAPTERS);
+let highlighted = [];
+
+function clearHighlights() {
+  highlighted.forEach(el => {
+    el.style.backgroundColor = '';
+  });
+  highlighted = [];
+}
+
+function updateSources(ch, element) {
+  clearHighlights();
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
-  let sources = [];
+  let sequence = [];
   if (Array.isArray(ch)) {
-    sources = [...new Set(ch)];
+    sequence = ch.slice();
   } else if (ch === null) {
     const all = Object.values(CHAPTER_SOURCES).flat();
-    sources = [...new Set(all)];
+    sequence = all.slice();
   } else {
-    sources = CHAPTER_SOURCES[ch] || [];
+    sequence = CHAPTER_SOURCES[ch] || [];
   }
-  sources.forEach(src => {
+  if (!sequence.length) return;
+
+  const uniqueSources = [...new Set(sequence)];
+  const colorMap = {};
+  let colorIdx = 0;
+  let pdfColor = null;
+  uniqueSources.forEach(src => {
+    let color;
+    if (src.toLowerCase().endsWith('.pdf')) {
+      if (!pdfColor) {
+        pdfColor = COLORS[colorIdx % COLORS.length];
+        colorIdx++;
+      }
+      color = pdfColor;
+    } else {
+      color = COLORS[colorIdx % COLORS.length];
+      colorIdx++;
+    }
+    colorMap[src] = color;
     const li = document.createElement('li');
     li.className = 'list-group-item';
     li.textContent = src;
+    li.style.backgroundColor = color;
     list.appendChild(li);
   });
+
+  if (element) {
+    let node = element.nextElementSibling;
+    let idx = 0;
+    const markers = sequence.map(src => {
+      const sec = src.match(/章節\s*([\d\.]+)/);
+      if (sec) return {type: 'section', value: sec[1]};
+      const title = src.match(/標題\s*(.+)/);
+      return title ? {type: 'title', value: title[1]} : null;
+    });
+    const findNextMarkerIdx = from => {
+      for (let i = from + 1; i < markers.length; i++) {
+        if (markers[i]) return i;
+      }
+      return -1;
+    };
+    let nextIdx = findNextMarkerIdx(0);
+    let nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+    while (node && !CHAPTER_SET.has(node.textContent.trim())) {
+      const text = node.textContent.trim();
+      if (nextMarker && highlighted.length && (
+          (nextMarker.type === 'section' && text.startsWith(nextMarker.value)) ||
+          (nextMarker.type === 'title' && text.includes(nextMarker.value))
+        )) {
+        idx = nextIdx;
+        nextIdx = findNextMarkerIdx(idx);
+        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+      }
+      const src = sequence[idx] || sequence[sequence.length - 1];
+      node.style.backgroundColor = colorMap[src];
+      highlighted.push(node);
+      if (markers[idx] && markers[idx].type === 'title') {
+        idx = nextIdx;
+        nextIdx = findNextMarkerIdx(idx);
+        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+      }
+      node = node.nextElementSibling;
+    }
+  }
 }
 
 const iframe = document.getElementById('htmlFrame');
@@ -46,7 +116,7 @@ iframe.addEventListener('load', () => {
       found = true;
       elements.forEach(el => {
         el.style.cursor = 'pointer';
-        el.addEventListener('click', () => updateSources(ch));
+        el.addEventListener('click', () => updateSources(ch, el));
       });
     } else {
       unhandled = unhandled.concat(CHAPTER_SOURCES[ch] || []);


### PR DESCRIPTION
## Summary
- highlight chapter sections using source-based colors
- group ZIP-extracted PDFs under a single highlight
- differentiate Word heading extractions with distinct colors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0984780832388ffef77dfab79ef