### PR TITLE
Skip capturing chapter titles in Word extraction

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -210,6 +210,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
                 if capture_mode and paragraph_text:


### PR DESCRIPTION
## Summary
- Prevent `extract_word_chapter` from including chapter titles in extracted output by skipping matched section headers.

## Testing
- `python -m py_compile modules/Extract_AllFile_to_FinalWord.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ccccddf08323891856f7f5fbc4ab