### PR TITLE
fix color highlighting after chapter extraction

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -210,6 +210,11 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    marker_para = section.AddParagraph()
+                    marker_run = marker_para.AppendText(paragraph_text)
+                    marker_run.CharacterFormat.TextColor = Color.White
+                    marker_para.Format.BeforeSpacing = 0
+                    marker_para.Format.AfterSpacing = 0
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -91,6 +91,15 @@ function updateSources(ch, element) {
         idx = nextIdx;
         nextIdx = findNextMarkerIdx(idx);
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+        node = node.nextElementSibling;
+        continue;
+      }
+      if (!highlighted.length && markers[idx] && (
+          (markers[idx].type === 'section' && text.startsWith(markers[idx].value)) ||
+          (markers[idx].type === 'title' && text.includes(markers[idx].value))
+        )) {
+        node = node.nextElementSibling;
+        continue;
       }
       const src = sequence[idx] || sequence[sequence.length - 1];
       node.style.backgroundColor = colorMap[src];


### PR DESCRIPTION
## Summary
- ensure `extract_word_chapter` inserts hidden markers for chapter boundaries
- skip marker lines during HTML comparison so highlighting works without showing extra headings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a7d435d7ac83239428d6bb9186e434