### PR TITLE
Strip headings from downloaded DOCX

### DIFF
--- a/app.py
+++ b/app.py
@@ -534,8 +534,41 @@ def task_download(task_id, job_id, kind):
     tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
     job_dir = os.path.join(tdir, "jobs", job_id)
     if kind == "docx":
+        result_docx = os.path.join(job_dir, "result.docx")
+        log_path = os.path.join(job_dir, "log.json")
+        stripped_docx = os.path.join(job_dir, "result_no_headings.docx")
+
+        chapters = []
+        if os.path.exists(log_path):
+            with open(log_path, "r", encoding="utf-8") as f:
+                entries = json.load(f)
+            for entry in entries:
+                if entry.get("type") == "insert_roman_heading":
+                    text = entry.get("params", {}).get("text", "").strip()
+                    if text:
+                        chapters.append(text)
+
+        import docx
+        doc = docx.Document(result_docx)
+        for p in list(doc.paragraphs):
+            txt = p.text.strip()
+            removed = False
+            for ch in chapters:
+                idx = txt.find(ch)
+                if idx != -1:
+                    after = txt[idx + len(ch):].lstrip(" ：:-　")
+                    if after:
+                        p.text = after
+                    else:
+                        p._element.getparent().remove(p._element)
+                    removed = True
+                    break
+            if not removed and p.style.name.lower().startswith("heading"):
+                p._element.getparent().remove(p._element)
+        doc.save(stripped_docx)
+
         return send_file(
-            os.path.join(job_dir, "result.docx"),
+            stripped_docx,
             as_attachment=True,
             download_name=f"result_{job_id}.docx",
         )


### PR DESCRIPTION
## Summary
- Remove chapter headings by dropping heading paragraphs or trimming heading prefixes when content follows

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d7695148832390571993d2cb7e3f