### PR TITLE
feat: open source files in comparison view

### DIFF
--- a/app.py
+++ b/app.py
@@ -475,6 +475,7 @@ def task_compare(task_id, job_id):
         doc.SaveToFile(html_path, FileFormat.Html)
         doc.Close()
 
+    files_dir = os.path.join(tdir, "files")
     chapter_sources = {}
     current = None
     with open(log_path, "r", encoding="utf-8") as f:
@@ -492,9 +493,18 @@ def task_compare(task_id, job_id):
                 import zipfile
                 with zipfile.ZipFile(zip_path, "r") as zf:
                     pdfs = [os.path.basename(n) for n in zf.namelist() if not n.endswith("/")]
-            chapter_sources.setdefault(current or "未分類", []).extend(pdfs)
+            for pdf in pdfs:
+                url = url_for(
+                    "task_view_file",
+                    task_id=task_id,
+                    job_id=job_id,
+                    filename=f"pdfs_extracted/{pdf}",
+                )
+                chapter_sources.setdefault(current or "未分類", []).append({"name": pdf, "url": url})
         elif stype == "extract_word_chapter":
-            infile = os.path.basename(params.get("input_file", ""))
+            input_path = params.get("input_file", "")
+            rel_path = os.path.relpath(input_path, files_dir) if input_path else ""
+            infile = os.path.basename(input_path)
             sec = params.get("target_chapter_section", "")
             use_title = str(params.get("target_title", "")).lower() in ["1", "true", "yes", "on"]
             title = params.get("target_title_section", "") if use_title else ""
@@ -503,10 +513,14 @@ def task_compare(task_id, job_id):
                 info += f" 章節 {sec}"
             if title:
                 info += f" 標題 {title}"
-            chapter_sources.setdefault(current or "未分類", []).append(info)
+            url = url_for("task_view_source", task_id=task_id, filename=rel_path)
+            chapter_sources.setdefault(current or "未分類", []).append({"name": info, "url": url})
         elif stype == "extract_word_all_content":
-            infile = os.path.basename(params.get("input_file", ""))
-            chapter_sources.setdefault(current or "未分類", []).append(infile)
+            input_path = params.get("input_file", "")
+            rel_path = os.path.relpath(input_path, files_dir) if input_path else ""
+            infile = os.path.basename(input_path)
+            url = url_for("task_view_source", task_id=task_id, filename=rel_path)
+            chapter_sources.setdefault(current or "未分類", []).append({"name": infile, "url": url})
 
     chapters = list(chapter_sources.keys())
     html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
@@ -516,7 +530,33 @@ def task_compare(task_id, job_id):
         chapters=chapters,
         chapter_sources=chapter_sources,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
+        task_id=task_id,
+        job_id=job_id,
     )
+
+
+@app.get("/tasks/<task_id>/source/<path:filename>")
+def task_view_source(task_id, filename):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    files_dir = os.path.join(tdir, "files")
+    file_path = os.path.join(files_dir, filename)
+    if not os.path.isfile(file_path):
+        abort(404)
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".docx":
+        view_root = os.path.join(files_dir, "_view")
+        base, _ = os.path.splitext(filename)
+        html_rel = f"{base}.html"
+        html_path = os.path.join(view_root, html_rel)
+        os.makedirs(os.path.dirname(html_path), exist_ok=True)
+        if not os.path.exists(html_path):
+            from spire.doc import Document, FileFormat
+            doc = Document()
+            doc.LoadFromFile(file_path)
+            doc.SaveToFile(html_path, FileFormat.Html)
+            doc.Close()
+        return send_from_directory(os.path.dirname(html_path), os.path.basename(html_path))
+    return send_from_directory(files_dir, filename)
 
 
 @app.get("/tasks/<task_id>/view/<job_id>/<path:filename>")

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -41,37 +41,43 @@ function updateSources(ch, element) {
   }
   if (!sequence.length) return;
 
-  const uniqueSources = [...new Set(sequence)];
   const colorMap = {};
   let colorIdx = 0;
   let pdfColor = null;
-  uniqueSources.forEach(src => {
-    let color;
-    if (src.toLowerCase().endsWith('.pdf')) {
-      if (!pdfColor) {
-        pdfColor = COLORS[colorIdx % COLORS.length];
+  sequence.forEach(src => {
+    if (!colorMap[src.url]) {
+      let color;
+      if (src.name.toLowerCase().endsWith('.pdf')) {
+        if (!pdfColor) {
+          pdfColor = COLORS[colorIdx % COLORS.length];
+          colorIdx++;
+        }
+        color = pdfColor;
+      } else {
+        color = COLORS[colorIdx % COLORS.length];
         colorIdx++;
       }
-      color = pdfColor;
-    } else {
-      color = COLORS[colorIdx % COLORS.length];
-      colorIdx++;
+      colorMap[src.url] = color;
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      li.style.backgroundColor = color;
+      const a = document.createElement('a');
+      a.textContent = src.name;
+      a.href = src.url;
+      a.target = '_blank';
+      a.style.display = 'block';
+      li.appendChild(a);
+      list.appendChild(li);
     }
-    colorMap[src] = color;
-    const li = document.createElement('li');
-    li.className = 'list-group-item';
-    li.textContent = src;
-    li.style.backgroundColor = color;
-    list.appendChild(li);
   });
 
   if (element) {
     let node = element.nextElementSibling;
     let idx = 0;
     const markers = sequence.map(src => {
-      const title = src.match(/標題\s*(.+)/);
+      const title = src.name.match(/標題\s*(.+)/);
       if (title) return {type: 'title', value: title[1]};
-      const sec = src.match(/章節\s*([\d\.]+)/);
+      const sec = src.name.match(/章節\s*([\d\.]+)/);
       return sec ? {type: 'section', value: sec[1]} : null;
     });
     const findNextMarkerIdx = from => {
@@ -92,8 +98,8 @@ function updateSources(ch, element) {
         nextIdx = findNextMarkerIdx(idx);
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
       }
-      const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
+      const srcItem = sequence[idx] || sequence[sequence.length - 1];
+      node.style.backgroundColor = colorMap[srcItem.url];
       highlighted.push(node);
       if (markers[idx] && markers[idx].type === 'title') {
         idx = nextIdx;


### PR DESCRIPTION
## Summary
- add route to serve original task files
- build comparison metadata with URLs for each source file
- render source list as clickable links opening in new tabs
- convert source DOCX files to HTML for in-browser preview
- preserve nested paths for Word sources so links resolve correctly

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e67b9c688323bf4ef0702415b498