### PR TITLE
feat: preview source files in comparison view

### DIFF
--- a/app.py
+++ b/app.py
@@ -466,16 +466,19 @@ def task_compare(task_id, job_id):
     if not os.path.exists(docx_path) or not os.path.exists(log_path):
         abort(404)
 
+    from spire.doc import Document, FileFormat
+
     html_name = "result.html"
     html_path = os.path.join(job_dir, html_name)
     if not os.path.exists(html_path):
-        from spire.doc import Document, FileFormat
         doc = Document()
         doc.LoadFromFile(docx_path)
         doc.SaveToFile(html_path, FileFormat.Html)
         doc.Close()
 
     chapter_sources = {}
+    source_urls = {}
+    converted_docx = {}
     current = None
     with open(log_path, "r", encoding="utf-8") as f:
         entries = json.load(f)
@@ -486,27 +489,63 @@ def task_compare(task_id, job_id):
             current = params.get("text", "")
             chapter_sources.setdefault(current, [])
         elif stype == "extract_pdf_chapter_to_table":
-            zip_path = params.get("pdf_zip", "")
+            pdf_dir = os.path.join(job_dir, "pdfs_extracted")
             pdfs = []
-            if zip_path and os.path.exists(zip_path):
-                import zipfile
-                with zipfile.ZipFile(zip_path, "r") as zf:
-                    pdfs = [os.path.basename(n) for n in zf.namelist() if not n.endswith("/")]
+            if os.path.isdir(pdf_dir):
+                for fn in sorted(os.listdir(pdf_dir)):
+                    if fn.lower().endswith(".pdf"):
+                        pdfs.append(fn)
+                        rel = os.path.join("pdfs_extracted", fn)
+                        source_urls[fn] = url_for(
+                            "task_view_file", task_id=task_id, job_id=job_id, filename=rel
+                        )
             chapter_sources.setdefault(current or "未分類", []).extend(pdfs)
         elif stype == "extract_word_chapter":
-            infile = os.path.basename(params.get("input_file", ""))
+            infile = params.get("input_file", "")
+            base = os.path.basename(infile)
             sec = params.get("target_chapter_section", "")
             use_title = str(params.get("target_title", "")).lower() in ["1", "true", "yes", "on"]
             title = params.get("target_title_section", "") if use_title else ""
-            info = infile
+            info = base
             if sec:
                 info += f" 章節 {sec}"
             if title:
                 info += f" 標題 {title}"
             chapter_sources.setdefault(current or "未分類", []).append(info)
+            if base not in converted_docx and infile and os.path.exists(infile):
+                preview_dir = os.path.join(job_dir, "source_html")
+                os.makedirs(preview_dir, exist_ok=True)
+                html_name_src = f"{os.path.splitext(base)[0]}.html"
+                html_rel = os.path.join("source_html", html_name_src)
+                html_path_src = os.path.join(job_dir, html_rel)
+                doc = Document()
+                doc.LoadFromFile(infile)
+                doc.SaveToFile(html_path_src, FileFormat.Html)
+                doc.Close()
+                converted_docx[base] = html_rel
+            if base in converted_docx:
+                source_urls[info] = url_for(
+                    "task_view_file", task_id=task_id, job_id=job_id, filename=converted_docx[base]
+                )
         elif stype == "extract_word_all_content":
-            infile = os.path.basename(params.get("input_file", ""))
-            chapter_sources.setdefault(current or "未分類", []).append(infile)
+            infile = params.get("input_file", "")
+            base = os.path.basename(infile)
+            chapter_sources.setdefault(current or "未分類", []).append(base)
+            if base not in converted_docx and infile and os.path.exists(infile):
+                preview_dir = os.path.join(job_dir, "source_html")
+                os.makedirs(preview_dir, exist_ok=True)
+                html_name_src = f"{os.path.splitext(base)[0]}.html"
+                html_rel = os.path.join("source_html", html_name_src)
+                html_path_src = os.path.join(job_dir, html_rel)
+                doc = Document()
+                doc.LoadFromFile(infile)
+                doc.SaveToFile(html_path_src, FileFormat.Html)
+                doc.Close()
+                converted_docx[base] = html_rel
+            if base in converted_docx:
+                source_urls[base] = url_for(
+                    "task_view_file", task_id=task_id, job_id=job_id, filename=converted_docx[base]
+                )
 
     chapters = list(chapter_sources.keys())
     html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
@@ -515,6 +554,7 @@ def task_compare(task_id, job_id):
         html_url=html_url,
         chapters=chapters,
         chapter_sources=chapter_sources,
+        source_urls=source_urls,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
     )
 
@@ -523,10 +563,11 @@ def task_compare(task_id, job_id):
 def task_view_file(task_id, job_id, filename):
     tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
     job_dir = os.path.join(tdir, "jobs", job_id)
-    file_path = os.path.join(job_dir, filename)
+    safe_filename = filename.replace("\\", "/")
+    file_path = os.path.join(job_dir, safe_filename)
     if not os.path.isfile(file_path):
         abort(404)
-    return send_from_directory(job_dir, filename)
+    return send_from_directory(job_dir, safe_filename)
 
 
 @app.get("/tasks/<task_id>/download/<job_id>/<kind>")

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -12,12 +12,35 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="sourceModal" tabindex="-1">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">來源檔案預覽</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body p-0"></div>
+    </div>
+  </div>
+</div>
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
+const SOURCE_URLS = {{ source_urls|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
 const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
+
+function openModal(url, title) {
+  const modalEl = document.getElementById('sourceModal');
+  const modalTitle = modalEl.querySelector('.modal-title');
+  const modalBody = modalEl.querySelector('.modal-body');
+  modalTitle.textContent = title;
+  modalBody.innerHTML = `<iframe src="${url}" style="width:100%; height:70vh;" class="border-0 w-100"></iframe>`;
+  const modal = new bootstrap.Modal(modalEl);
+  modal.show();
+}
 
 function clearHighlights() {
   highlighted.forEach(el => {
@@ -62,6 +85,11 @@ function updateSources(ch, element) {
     li.className = 'list-group-item';
     li.textContent = src;
     li.style.backgroundColor = color;
+    const url = SOURCE_URLS[src];
+    if (url) {
+      li.style.cursor = 'pointer';
+      li.addEventListener('click', () => openModal(url, src));
+    }
     list.appendChild(li);
   });
 


### PR DESCRIPTION
## Summary
- convert source documents to HTML and map preview URLs in compare endpoint
- add modal to display source files and make list items clickable
- normalize file paths in preview route to avoid Not Found errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee7f9c088323afd8fcd6d9765c0a