### PR TITLE
feat: preview source files in comparison view

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -15,9 +15,14 @@
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
+const SOURCE_URLS = {{ source_urls|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
 const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
+
+function openWindow(url) {
+  window.open(url, '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
+}
 
 function clearHighlights() {
   highlighted.forEach(el => {
@@ -62,6 +67,11 @@ function updateSources(ch, element) {
     li.className = 'list-group-item';
     li.textContent = src;
     li.style.backgroundColor = color;
+    const url = SOURCE_URLS[src];
+    if (url) {
+      li.style.cursor = 'pointer';
+      li.addEventListener('click', () => openWindow(url));
+    }
     list.appendChild(li);
   });
 


### PR DESCRIPTION
## Summary
- convert source documents to HTML and map preview URLs in compare endpoint
- add popup window to display source files and make list items clickable
- embed images in HTML previews and normalize file paths in preview route to avoid Not Found errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee7f9c088323afd8fcd6d9765c0a