### PR TITLE
Allow editing and saving in compare view

### DIFF
--- a/app.py
+++ b/app.py
@@ -559,7 +559,30 @@ def task_compare(task_id, job_id):
         chapter_sources=chapter_sources,
         source_urls=source_urls,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
+        save_url=url_for("task_compare_save", task_id=task_id, job_id=job_id),
     )
+
+
+@app.post("/tasks/<task_id>/compare/<job_id>/save")
+def task_compare_save(task_id, job_id):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    job_dir = os.path.join(tdir, "jobs", job_id)
+    html_content = request.form.get("html")
+    if not html_content:
+        data = request.get_json(silent=True) or {}
+        html_content = data.get("html", "")
+    if not html_content:
+        return "缺少內容", 400
+    html_path = os.path.join(job_dir, "result.html")
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(html_content)
+    from spire.doc import Document, FileFormat
+
+    doc = Document()
+    doc.LoadFromFile(html_path, FileFormat.Html)
+    doc.SaveToFile(os.path.join(job_dir, "result.docx"), FileFormat.Docx)
+    doc.Close()
+    return "OK"
 
 
 @app.get("/tasks/<task_id>/view/<job_id>/<path:filename>")

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -7,7 +7,8 @@
   </div>
   <div class="col-md-4">
     <ul id="sourceList" class="list-group"></ul>
-    <div class="mt-3">
+    <div class="mt-3 d-flex gap-2">
+      <button id="saveBtn" class="btn btn-primary" type="button">保存</button>
       <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
     </div>
   </div>
@@ -130,6 +131,7 @@ function updateSources(ch, element) {
 const iframe = document.getElementById('htmlFrame');
 iframe.addEventListener('load', () => {
   const doc = iframe.contentDocument || iframe.contentWindow.document;
+  doc.designMode = 'on';
   let found = false;
   let unhandled = [];
   CHAPTERS.forEach(ch => {
@@ -149,6 +151,22 @@ iframe.addEventListener('load', () => {
   } else if (!found) {
     updateSources(null);
   }
+});
+
+document.getElementById('saveBtn').addEventListener('click', () => {
+  const doc = iframe.contentDocument || iframe.contentWindow.document;
+  const html = doc.documentElement.outerHTML;
+  fetch('{{ save_url }}', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({html})
+  }).then(r => {
+    if (r.ok) {
+      alert('已保存');
+    } else {
+      alert('保存失敗');
+    }
+  });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Enable editing of generated result in compare view and save changes
- Add backend endpoint converting edited HTML back to DOCX

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f4b8197083238d605f4771057c5e