### PR TITLE
feat: add file structure modal in flow builder

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,6 +268,7 @@ def flow_builder(task_id):
                 if isinstance(s, dict) and s.get("type") in SUPPORTED_STEPS
             ]
     avail = gather_available_files(files_dir)
+    tree = build_file_tree(files_dir)
     return render_template(
         "flow.html",
         task={"id": task_id},
@@ -277,6 +278,7 @@ def flow_builder(task_id):
         preset=preset,
         loaded_name=loaded_name,
         center_titles=center_titles,
+        files_tree=tree,
     )
 
 

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}
 {% block content %}
+{% macro render_tables(node, path="") %}
+  {% if node.files %}
+  <h3 class="h6 mt-3">{{ path or '根目錄' }}</h3>
+  <table class="table table-sm">
+    <tbody>
+      {% for fname in node.files %}
+      <tr><td>{{ fname }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+  {% for dname, dnode in node.dirs.items() %}
+    {{ render_tables(dnode, path ~ ("/" if path else "") ~ dname) }}
+  {% endfor %}
+{% endmacro %}
 <h1 class="h3 mb-3">定義流程</h1>
 
 <form id="flow_form" action="{{ url_for('run_flow', task_id=task.id) }}" method="post" class="vstack gap-3">
@@ -27,10 +42,25 @@
         {% endfor %}
       </ul>
     </div>
-    <button class="btn btn-success" type="submit" name="action" value="run">執行流程</button>
-    <button class="btn btn-secondary" type="submit" name="action" value="save">保存流程</button>
+      <button class="btn btn-success" type="submit" name="action" value="run">執行流程</button>
+      <button class="btn btn-secondary" type="submit" name="action" value="save">保存流程</button>
+      <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#filesModal">檔案結構</button>
+    </div>
+  </form>
+
+<div class="modal fade" id="filesModal" tabindex="-1" aria-labelledby="filesModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="filesModalLabel">檔案結構</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        {{ render_tables(files_tree) }}
+      </div>
+    </div>
   </div>
-</form>
+</div>
 
 <div class="mt-3">
 </div>


### PR DESCRIPTION
## Summary
- expose file tree to flow builder endpoint
- add modal and macro to display file structure in flow definition page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad022266888323bb3b14d11d308aae