### PR TITLE
feat: add interface for moving files by keyword

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from werkzeug.utils import secure_filename
 from modules.workflow import SUPPORTED_STEPS, run_workflow
 from modules.Extract_AllFile_to_FinalWord import center_table_figure_paragraphs
 from modules.translate_with_bedrock import translate_file
+from modules.file_mover import move_files
 
 app = Flask(__name__, instance_relative_config=True)
 app.config["SECRET_KEY"] = "dev-secret"
@@ -63,6 +64,16 @@ def build_file_tree(base_dir):
     return tree
 
 
+def list_dirs(base_dir):
+    dirs = []
+    for root, dirnames, _ in os.walk(base_dir):
+        rel_root = os.path.relpath(root, base_dir)
+        for d in dirnames:
+            path = os.path.normpath(os.path.join(rel_root, d))
+            dirs.append(path)
+    return sorted(dirs)
+
+
 def task_name_exists(name, exclude_id=None):
     for tid in os.listdir(app.config["TASK_FOLDER"]):
         if exclude_id and tid == exclude_id:
@@ -78,6 +89,45 @@ def task_name_exists(name, exclude_id=None):
         if tname == name:
             return True
     return False
+
+
+@app.route("/tasks/<task_id>/move-files", methods=["GET", "POST"])
+def move_files_view(task_id):
+    base = os.path.join(app.config["TASK_FOLDER"], task_id, "files")
+    if not os.path.isdir(base):
+        abort(404)
+    message = ""
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "create_dir":
+            new_rel = request.form.get("new_dir", "").strip()
+            if not new_rel:
+                message = "請輸入資料夾名稱"
+            else:
+                norm = os.path.normpath(new_rel)
+                if norm.startswith(".."):
+                    message = "資料夾名稱不合法"
+                else:
+                    os.makedirs(os.path.join(base, norm), exist_ok=True)
+                    message = f"已建立資料夾 {norm}"
+        else:
+            source_rel = request.form.get("source_dir", "").strip()
+            dest_rel = request.form.get("dest_dir", "").strip()
+            keywords_raw = request.form.get("keywords", "")
+            keywords = [k.strip() for k in keywords_raw.split(",") if k.strip()]
+            if not source_rel or not dest_rel or not keywords:
+                message = "請完整輸入資料"
+            else:
+                src = os.path.join(base, source_rel)
+                dest = os.path.join(base, dest_rel)
+                try:
+                    moved = move_files(src, dest, keywords)
+                    message = f"已移動 {len(moved)} 個檔案"
+                except Exception as e:
+                    message = str(e)
+    dirs = list_dirs(base)
+    dirs.insert(0, ".")
+    return render_template("move_files.html", dirs=dirs, message=message, task_id=task_id)
 
 
 @app.get("/")

--- a/modules/file_mover.py
+++ b/modules/file_mover.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+from typing import Iterable, List
+
+
+def move_files(source: str, destination: str, keywords: Iterable[str]) -> List[str]:
+    """Move files whose names contain any of the given keywords.
+
+    Parameters
+    ----------
+    source: str
+        Directory to search for files.
+    destination: str
+        Directory where matched files will be moved.
+    keywords: Iterable[str]
+        Keywords to look for in filenames. Matching is case-insensitive.
+
+    Returns
+    -------
+    List[str]
+        Paths of the files after they have been moved.
+    """
+    if not os.path.isdir(source):
+        raise ValueError(f"Source directory '{source}' does not exist")
+
+    os.makedirs(destination, exist_ok=True)
+    moved_files: List[str] = []
+    keywords_lower = [k.lower() for k in keywords]
+
+    for root, _dirs, files in os.walk(source):
+        for name in files:
+            if any(k in name.lower() for k in keywords_lower):
+                src_path = os.path.join(root, name)
+                dest_path = os.path.join(destination, name)
+                base, ext = os.path.splitext(name)
+                count = 1
+                while os.path.exists(dest_path):
+                    dest_path = os.path.join(destination, f"{base}_{count}{ext}")
+                    count += 1
+                shutil.move(src_path, dest_path)
+                moved_files.append(dest_path)
+    return moved_files
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Move files whose names contain keywords")
+    parser.add_argument("source", help="Directory to search")
+    parser.add_argument("destination", help="Directory to move files to")
+    parser.add_argument("keywords", nargs="+", help="Keywords to match against filenames")
+    args = parser.parse_args()
+
+    results = move_files(args.source, args.destination, args.keywords)
+    print(f"Moved {len(results)} file(s).")

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,9 @@
           法規系統
           <img src="{{ url_for('static', filename='logo.svg') }}" alt="Logo" class="ms-2" style="height:24px;">
         </a>
-        <a class="btn btn-outline-primary" href="{{ url_for('tasks') }}">回首頁</a>
+        <div class="btn-group">
+          <a class="btn btn-outline-primary" href="{{ url_for('tasks') }}">回首頁</a>
+        </div>
       </div>
     </nav>
     <main class="container my-4">

--- a/templates/move_files.html
+++ b/templates/move_files.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h3 mb-3">移動檔案</h1>
+{% if message %}
+<div class="alert alert-info">{{ message }}</div>
+{% endif %}
+<form method="post" class="vstack gap-3" action="{{ url_for('move_files_view', task_id=task_id) }}">
+  <input type="hidden" name="action" value="move">
+  <div>
+    <label class="form-label">來源資料夾</label>
+    <select class="form-select" name="source_dir" required>
+      <option value="" disabled selected>選擇資料夾</option>
+      {% for d in dirs %}
+      <option value="{{ d }}">{{ d }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="form-label">目的資料夾</label>
+    <input class="form-control" name="dest_dir" list="dirlist" placeholder="輸入或選擇目的資料夾" required>
+    <datalist id="dirlist">
+      {% for d in dirs %}<option value="{{ d }}">{{ d }}</option>{% endfor %}
+    </datalist>
+  </div>
+  <div>
+    <label class="form-label">關鍵字（以逗號分隔）</label>
+    <input class="form-control" name="keywords" placeholder="例如：EO,Gamma" required>
+  </div>
+  <div class="d-flex gap-2">
+    <button class="btn btn-primary" type="submit">移動</button>
+    <a class="btn btn-outline-secondary" href="{{ url_for('task_detail', task_id=task_id) }}">返回任務</a>
+  </div>
+</form>
+
+<hr class="my-4">
+
+<form method="post" class="vstack gap-2" action="{{ url_for('move_files_view', task_id=task_id) }}">
+  <input type="hidden" name="action" value="create_dir">
+  <label class="form-label">新增資料夾</label>
+  <div class="input-group">
+    <input class="form-control" name="new_dir" placeholder="例如：新資料夾" required>
+    <button class="btn btn-outline-secondary" type="submit">建立</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -39,6 +39,7 @@
 
 <div class="d-flex gap-2">
   <a class="btn btn-primary" href="{{ url_for('flow_builder', task_id=task.id) }}">管理流程</a>
+  <a class="btn btn-outline-primary" href="{{ url_for('move_files_view', task_id=task.id) }}">移動檔案</a>
   <a class="btn btn-outline-secondary" href="{{ url_for('tasks') }}">回首頁</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- scope file moving to each task's `files` directory and expose `move-files` under `/tasks/<task_id>/`
- add button from task details to the keyword-based file mover and remove global nav entry
- allow creating new folders directly from the keyword-based file mover

## Testing
- `/bin/python3 -m py_compile app.py modules/file_mover.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae644519748323b31582660c0e88d8