### PR TITLE
Fix table alignment after compare edits

### DIFF
--- a/app.py
+++ b/app.py
@@ -646,8 +646,11 @@ def task_compare_save(task_id, job_id):
 
     doc = Document()
     doc.LoadFromFile(html_path, FileFormat.Html)
-    doc.SaveToFile(os.path.join(job_dir, "result.docx"), FileFormat.Docx)
+    output_docx = os.path.join(job_dir, "result.docx")
+    doc.SaveToFile(output_docx, FileFormat.Docx)
     doc.Close()
+    # Re-apply centering for table and figure captions after editing
+    center_table_figure_paragraphs(output_docx)
     return "OK"
 
 


### PR DESCRIPTION
## Summary
- Reapply table and figure caption centering after saving edited comparison HTML

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae865554548323a681a6dcb4f3c8df