### PR TITLE
Fix table alignment after compare edits

### DIFF
--- a/app.py
+++ b/app.py
@@ -646,8 +646,11 @@ def task_compare_save(task_id, job_id):
 
     doc = Document()
     doc.LoadFromFile(html_path, FileFormat.Html)
-    doc.SaveToFile(os.path.join(job_dir, "result.docx"), FileFormat.Docx)
+    output_docx = os.path.join(job_dir, "result.docx")
+    doc.SaveToFile(output_docx, FileFormat.Docx)
     doc.Close()
+    # Re-apply centering for table and figure captions after editing
+    center_table_figure_paragraphs(output_docx)
     return "OK"
 
 

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -262,12 +262,15 @@ def center_table_figure_paragraphs(input_file: str) -> bool:
                 paragraph_text = paragraph_text.strip()
                 if pattern.match(paragraph_text):
                     child.Format.HorizontalAlignment = HorizontalAlignment.Center
+            elif isinstance(child, Table):
+                child.AutoFit(AutoFitBehaviorType.AutoFitToWindow)
+                nodes.put(child)
             elif isinstance(child, ICompositeObject):
                 nodes.put(child)
 
     try:
         doc.SaveToFile(input_file, FileFormat.Docx)
-        print(f"{input_file}，以將表格標題或圖片標題置中")
+        print(f"{input_file}，以將表格標題或圖片標題置中並調整表格寬度")
         return True
     except Exception as e:
         print(f"錯誤：保存文件 {input_file} 時出錯: {str(e)}")


### PR DESCRIPTION
## Summary
- Auto-fit tables to page width when re-centering captions after saving edited comparison HTML

## Testing
- `python -m py_compile app.py modules/Extract_AllFile_to_FinalWord.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae865554548323a681a6dcb4f3c8df