### PR TITLE
feat: move files when all keywords match

### DIFF
--- a/modules/file_mover.py
+++ b/modules/file_mover.py
@@ -4,7 +4,10 @@ from typing import Iterable, List
 
 
 def move_files(source: str, destination: str, keywords: Iterable[str]) -> List[str]:
-    """Move files whose names contain any of the given keywords.
+    """Move files whose names contain all provided keywords.
+
+    Keywords are matched case-insensitively. A file is moved only when its
+    name contains *all* of the specified keywords.
 
     Parameters
     ----------
@@ -13,7 +16,7 @@ def move_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
     destination: str
         Directory where matched files will be moved.
     keywords: Iterable[str]
-        Keywords to look for in filenames. Matching is case-insensitive.
+        Keywords that must all be present in the filename.
 
     Returns
     -------
@@ -25,11 +28,12 @@ def move_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
 
     os.makedirs(destination, exist_ok=True)
     moved_files: List[str] = []
-    keywords_lower = [k.lower() for k in keywords]
+    lowered_keywords = [k.strip().lower() for k in keywords if k.strip()]
 
     for root, _dirs, files in os.walk(source):
         for name in files:
-            if any(k in name.lower() for k in keywords_lower):
+            lower_name = name.lower()
+            if all(k in lower_name for k in lowered_keywords):
                 src_path = os.path.join(root, name)
                 dest_path = os.path.join(destination, name)
                 base, ext = os.path.splitext(name)
@@ -50,7 +54,7 @@ if __name__ == "__main__":
     parser.add_argument("destination", help="Directory to move files to")
     parser.add_argument(
         "keywords",
-        help="Comma-separated keywords to match against filenames",
+        help="Comma-separated keywords that must all appear in the filename",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- require file names to contain all specified keywords
- clarify keyword input instructions in UI and CLI

## Testing
- `python -m py_compile modules/file_mover.py app.py`
- `pytest`
- `python - <<'PY'\nimport os, tempfile\nfrom modules.file_mover import move_files\n\nsrc = tempfile.mkdtemp()\ndest = tempfile.mkdtemp()\n# Create sample files\nopen(os.path.join(src, 'UOC-RD-TR-18031_v0 Shipping simulation test_EO.txt'), 'w').close()\nopen(os.path.join(src, 'UOC-RD-TR-19024_v0 Shipping simulation test_Gamma.txt'), 'w').close()\nopen(os.path.join(src, 'other.txt'), 'w').close()\n\nmoved = move_files(src, dest, ['Shipping simulation test', 'EO'])\nprint('moved files:', [os.path.basename(p) for p in moved])\n\n# Clean up to avoid leftover\nimport shutil\nshutil.rmtree(src)\nshutil.rmtree(dest)\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68ae986073d48323899f50d4a0ff3b00