### PR TITLE
Preserve table separation when extracting Word content

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -110,6 +110,9 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
     def add_table_to_section(sec, table):
         try:
             cloned = table.Clone()
+            cloned.TableFormat.IsBreakAcrossPages = False
+            for i in range(cloned.Rows.Count):
+                cloned.Rows.get_Item(i).RowFormat.IsBreakAcrossPages = False
             sec.Tables.Add(cloned)
         except Exception as e:
             print("處理表格錯誤:", e)
@@ -133,8 +136,9 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
                             img.write(sub.ImageBytes)
                         paragraph_text += f"[Image: {file_name}]"
                         image_count[0] += 1
+
+                para = section.AddParagraph()
                 if paragraph_text.strip():
-                    para = section.AddParagraph()
                     for part in re.split(r'(\[Image:.+?\])', paragraph_text):
                         if part.startswith("[Image:"):
                             img_name = part[7:-1].strip()
@@ -184,6 +188,9 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
     def add_table_to_section(sec, table):
         try:
             cloned = table.Clone()
+            cloned.TableFormat.IsBreakAcrossPages = False
+            for i in range(cloned.Rows.Count):
+                cloned.Rows.get_Item(i).RowFormat.IsBreakAcrossPages = False
             sec.Tables.Add(cloned)
         except Exception as e:
             print("處理表格錯誤:", e)
@@ -212,17 +219,18 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                     capture_mode = True
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
-                if capture_mode and paragraph_text:
+                if capture_mode:
                     para = section.AddParagraph()
-                    for part in re.split(r'(\[Image:.+?\])', paragraph_text):
-                        if part.startswith("[Image:"):
-                            img_name = part[7:-1].strip()
-                            img_path = os.path.join(output_image_path, img_name)
-                            if os.path.isfile(img_path):
-                                para.AppendPicture(img_path)
-                                para.Format.HorizontalAlignment = HorizontalAlignment.Center
-                        else:
-                            para.AppendText(part)
+                    if paragraph_text:
+                        for part in re.split(r'(\[Image:.+?\])', paragraph_text):
+                            if part.startswith("[Image:"):
+                                img_name = part[7:-1].strip()
+                                img_path = os.path.join(output_image_path, img_name)
+                                if os.path.isfile(img_path):
+                                    para.AppendPicture(img_path)
+                                    para.Format.HorizontalAlignment = HorizontalAlignment.Center
+                            else:
+                                para.AppendText(part)
             elif isinstance(child, Table) and capture_mode:
                 add_table_to_section(section, child)
             elif isinstance(child, ICompositeObject):


### PR DESCRIPTION
## Summary
- prevent Word tables from merging by keeping empty paragraphs when extracting full content
- maintain table boundaries during chapter extraction by inserting placeholder paragraphs
- keep extracted tables on a single page by disabling row breaks across pages

## Testing
- `pytest`
- `python -m py_compile modules/Extract_AllFile_to_FinalWord.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea20515748323bc9f897af2abdd57