### PR TITLE
Skip Word headers and footers during extraction

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -161,7 +161,14 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
                             para.AppendText(part)
             elif isinstance(child, Table):
                 add_table_to_section(section, child)
+            elif isinstance(child, Section):
+                # Avoid traversing headers and footers by enqueueing only the body
+                nodes.put(child.Body)
             elif isinstance(child, ICompositeObject):
+                # Skip explicit Header and Footer objects
+                doc_type = getattr(child, "DocumentObjectType", None)
+                if doc_type in (DocumentObjectType.Header, DocumentObjectType.Footer):
+                    continue
                 nodes.put(child)
 
     if is_standalone:


### PR DESCRIPTION
## Summary
- prevent Word extraction from traversing headers and footers by queuing only section bodies
- ignore Header and Footer document object types during traversal

## Testing
- `pytest`
- `python - <<'PY'
from modules.Extract_AllFile_to_FinalWord import extract_word_all_content
from docx import Document as DocxDocument

doc = DocxDocument()
section = doc.sections[0]
section.header.paragraphs[0].text = 'HeaderText'
section.footer.paragraphs[0].text = 'FooterText'
section.header.paragraphs[0].alignment = 1
section.footer.paragraphs[0].alignment = 1
doc.add_paragraph('BodyText')
doc.save('sample.docx')

extract_word_all_content('sample.docx', output_image_path='out_images')

from docx import Document as DocxDocument
out_doc = DocxDocument('word_all_result.docx')
print('Output paragraphs:', [p.text for p in out_doc.paragraphs])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b151ede7488323b383ce16de1038fe