### PR TITLE
Skip section headers during chapter extraction

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -235,6 +235,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
                 if capture_mode:


### PR DESCRIPTION
## Summary
- prevent section titles from being written into extracted Word chapters by skipping matched headings

## Testing
- `python - <<'PY'
from modules.Extract_AllFile_to_FinalWord import extract_word_chapter
extract_word_chapter('test_spire3.docx','1.')
print('extraction done')
PY`
- `python - <<'PY'
from docx import Document
doc = Document('word_chapter_result.docx')
for i, para in enumerate(doc.paragraphs):
    print(i, para.text)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b15b437cf08323af9eabbb0b4ae595