### PR TITLE
Tag source segments and simplify compare highlighting

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import json
 import zipfile
+import re
 from datetime import datetime
 from flask import (
     Flask,
@@ -592,6 +593,20 @@ def task_compare(task_id, job_id):
         doc.HtmlExportOptions.ImageEmbedded = True
         doc.SaveToFile(html_path, FileFormat.Html)
         doc.Close()
+
+    with open(html_path, "r", encoding="utf-8") as f:
+        html_data = f.read()
+    pattern = re.compile(
+        r"<p[^>]*>\s*<span[^>]*>\s*\[\[SOURCE:(.*?)\]\]\s*</span>\s*</p>(.*?)<p[^>]*>\s*<span[^>]*>\s*\[\[/SOURCE\]\]\s*</span>\s*</p>",
+        re.DOTALL,
+    )
+    html_data = re.sub(
+        pattern,
+        lambda m: f'<span data-source="{m.group(1)}">{m.group(2)}</span>',
+        html_data,
+    )
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(html_data)
 
     chapter_sources = {}
     source_urls = {}

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -92,7 +92,11 @@ def extract_pdf_chapter_to_table(pdf_folder_path: str, target_section: str, outp
 
         table_filename = filename.split(' ')[0]
         cell1.AddParagraph().AppendText(table_filename)
+        start_para = cell2.AddParagraph()
+        start_para.AppendText(f"[[SOURCE:{filename}]]")
         cell2.AddParagraph().AppendText(extracted_text)
+        end_para = cell2.AddParagraph()
+        end_para.AppendText("[[/SOURCE]]")
         table.Rows.Add(new_row)
 
     if is_standalone:
@@ -113,6 +117,8 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
         is_standalone = True
     else:
         is_standalone = False
+    start_para = section.AddParagraph()
+    start_para.AppendText(f"[[SOURCE:{os.path.basename(input_file)}]]")
 
     nodes = queue.Queue()
     nodes.put(input_doc)
@@ -170,6 +176,8 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
                 if doc_type in (DocumentObjectType.Header, DocumentObjectType.Footer):
                     continue
                 nodes.put(child)
+    end_para = section.AddParagraph()
+    end_para.AppendText("[[/SOURCE]]")
 
     if is_standalone:
         output_doc.SaveToFile("word_all_result.docx", FileFormat.Docx)
@@ -197,6 +205,8 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
         is_standalone = True
     else:
         is_standalone = False
+    start_para = section.AddParagraph()
+    start_para.AppendText(f"[[SOURCE:{os.path.basename(input_file)}]]")
 
     nodes = queue.Queue()
     nodes.put(input_doc)
@@ -254,6 +264,8 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 add_table_to_section(section, child)
             elif isinstance(child, ICompositeObject):
                 nodes.put(child)
+    end_para = section.AddParagraph()
+    end_para.AppendText("[[/SOURCE]]")
 
     if is_standalone:
         output_doc.SaveToFile("word_chapter_result.docx", FileFormat.Docx)

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -35,7 +35,6 @@ const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
 const SOURCE_URLS = {{ source_urls|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
-const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
 
 function openWindow(url) {
@@ -49,7 +48,7 @@ function clearHighlights() {
   highlighted = [];
 }
 
-function updateSources(ch, element) {
+function updateSources(ch) {
   clearHighlights();
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
@@ -57,21 +56,13 @@ function updateSources(ch, element) {
   if (Array.isArray(ch)) {
     sequence = ch.slice();
   } else if (ch === null) {
-    const all = Object.values(CHAPTER_SOURCES).flat();
-    sequence = all.slice();
+    sequence = Object.values(CHAPTER_SOURCES).flat();
   } else {
     sequence = CHAPTER_SOURCES[ch] || [];
   }
   if (!sequence.length) return;
 
-  const entries = sequence.map(src => {
-    const title = src.match(/標題\s*(.+)/);
-    if (title) return {source: src, marker: {type: 'title', value: title[1]}};
-    const sec = src.match(/章節\s*([\d\.]+)/);
-    return {source: src, marker: sec ? {type: 'section', value: sec[1]} : null};
-  });
-
-  const uniqueSources = [...new Set(entries.map(e => e.source))];
+  const uniqueSources = [...new Set(sequence)];
   const colorMap = {};
   let colorIdx = 0;
   let pdfColor = null;
@@ -100,26 +91,17 @@ function updateSources(ch, element) {
     list.appendChild(li);
   });
 
-  if (element) {
-    let node = element.nextElementSibling;
-    let idx = 0;
-    while (node && idx < entries.length && !CHAPTER_SET.has(node.textContent.trim())) {
-      const {source, marker} = entries[idx];
-      node.style.backgroundColor = colorMap[source];
+  const nodes = doc.body.querySelectorAll('[data-source]');
+  nodes.forEach(node => {
+    const src = node.getAttribute('data-source');
+    const color = colorMap[src];
+    if (color) {
+      node.style.backgroundColor = color;
       highlighted.push(node);
-
-      const nextNode = node.nextElementSibling;
-      if (!nextNode) break;
-      const nextText = nextNode.textContent.trim();
-      if (!marker || !(
-          (marker.type === 'section' && nextText.startsWith(marker.value)) ||
-          (marker.type === 'title' && nextText.includes(marker.value))
-        )) {
-        idx++;
-      }
-      node = nextNode;
+    } else {
+      node.style.backgroundColor = '';
     }
-  }
+  });
 }
 
 const iframe = document.getElementById('htmlFrame');
@@ -146,7 +128,7 @@ iframe.addEventListener('load', () => {
       found = true;
       elements.forEach(el => {
         el.style.cursor = 'pointer';
-        el.addEventListener('click', () => updateSources(ch, el));
+        el.addEventListener('click', () => updateSources(ch));
       });
     } else {
       unhandled = unhandled.concat(CHAPTER_SOURCES[ch] || []);


### PR DESCRIPTION
## Summary
- Insert start/end `[[SOURCE]]` markers in extraction routines to track originating files
- Convert sentinel markers to `<span data-source>` during compare view generation
- Streamline client-side highlighting to color all `[data-source]` spans

## Testing
- `python -m py_compile app.py modules/Extract_AllFile_to_FinalWord.py`
- `node - <<'NODE' ...` (simulate highlighting)


------
https://chatgpt.com/codex/tasks/task_e_68b1604ec9cc8323b7c1ef4ec1588f0a