### PR TITLE
feat: highlight all sources on load

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -136,7 +136,7 @@ iframe.addEventListener('load', () => {
   });
   if (unhandled.length) {
     updateSources(unhandled);
-  } else if (!found) {
+  } else {
     updateSources(null);
   }
 });


### PR DESCRIPTION
## Summary
- color all data-source nodes as soon as the comparison page loads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b16299a8e4832386a02cd1cbf7dfb8