### PR TITLE
Expose HTML output and color-aware workflow logs

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -235,6 +235,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
                 if capture_mode:

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -14,38 +14,38 @@ from .Extract_AllFile_to_FinalWord import (
 SUPPORTED_STEPS = {
     "extract_pdf_chapter_to_table": {
         "label": "擷取 PDF 章節至表格（上傳 ZIP）",
-        "inputs": ["pdf_zip", "target_section"],
-        "accepts": {"pdf_zip": "file:zip", "target_section": "text"}
+        "inputs": ["pdf_zip", "target_section", "color"],
+        "accepts": {"pdf_zip": "file:zip", "target_section": "text", "color": "color"}
     },
     "extract_word_all_content": {
         "label": "擷取 Word 全部內容",
-        "inputs": ["input_file"],
-        "accepts": {"input_file": "file:docx"}
+        "inputs": ["input_file", "color"],
+        "accepts": {"input_file": "file:docx", "color": "color"}
     },
     "extract_word_chapter": {
         "label": "擷取 Word 指定章節/標題",
-        "inputs": ["input_file", "target_chapter_section", "target_title", "target_title_section"],
-        "accepts": {"input_file": "file:docx", "target_chapter_section": "text", "target_title": "bool", "target_title_section": "text"}
+        "inputs": ["input_file", "target_chapter_section", "target_title", "target_title_section", "color"],
+        "accepts": {"input_file": "file:docx", "target_chapter_section": "text", "target_title": "bool", "target_title_section": "text", "color": "color"}
     },
     "insert_text": {
         "label": "插入純文字段落",
-        "inputs": ["text", "align", "bold", "font_size", "before_space", "after_space", "page_break_before"],
-        "accepts": {"text":"text","align":"align","bold":"bool","font_size":"float","before_space":"float","after_space":"float","page_break_before":"bool"}
+        "inputs": ["text", "align", "bold", "font_size", "before_space", "after_space", "page_break_before", "color"],
+        "accepts": {"text":"text","align":"align","bold":"bool","font_size":"float","before_space":"float","after_space":"float","page_break_before":"bool","color":"color"}
     },
     "insert_numbered_heading": {
         "label": "插入阿拉伯數字標題",
-        "inputs": ["text", "level", "bold", "font_size"],
-        "accepts": {"text":"text","level":"int","bold":"bool","font_size":"float"}
+        "inputs": ["text", "level", "bold", "font_size", "color"],
+        "accepts": {"text":"text","level":"int","bold":"bool","font_size":"float","color":"color"}
     },
     "insert_roman_heading": {
         "label": "插入羅馬數字標題",
-        "inputs": ["text", "level", "bold", "font_size"],
-        "accepts": {"text":"text","level":"int","bold":"bool","font_size":"float"}
+        "inputs": ["text", "level", "bold", "font_size", "color"],
+        "accepts": {"text":"text","level":"int","bold":"bool","font_size":"float","color":"color"}
     },
     "insert_bulleted_heading": {
         "label": "插入項目符號標題",
-        "inputs": ["text", "font_size"],
-        "accepts": {"text":"text","font_size":"float"}
+        "inputs": ["text", "font_size", "color"],
+        "accepts": {"text":"text","font_size":"float","color":"color"}
     }
 }
 
@@ -60,7 +60,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
     for idx, step in enumerate(steps, start=1):
         stype = step.get("type")
         params = step.get("params", {})
-        log.append({"step": idx, "type": stype, "params": params})
+        log.append({"step": idx, "type": stype, "params": params, "color": params.get("color")})
         try:
             if stype == "extract_pdf_chapter_to_table":
                 import zipfile
@@ -136,6 +136,10 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
 
     out_docx = os.path.join(workdir, "result.docx")
     output_doc.SaveToFile(out_docx, FileFormat.Docx)
+    output_doc.HtmlExportOptions.ImageEmbedded = True
+    stream = Stream()
+    output_doc.SaveToStream(stream, FileFormat.Html)
+    html_content = stream.ToArray().decode("utf-8")
     output_doc.Close()
 
     out_log = os.path.join(workdir, "log.json")
@@ -143,4 +147,4 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
         import json
         json.dump(log, f, ensure_ascii=False, indent=2)
 
-    return {"result_docx": out_docx, "log": out_log, "log_json": log}
+    return {"result_docx": out_docx, "result_html": html_content, "log": out_log, "log_json": log}

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -34,7 +34,7 @@
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
 const SOURCE_URLS = {{ source_urls|tojson }};
-const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
+const COLOR_MAP = {{ colors|tojson }};
 const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
 
@@ -65,26 +65,13 @@ function updateSources(ch, element) {
   if (!sequence.length) return;
 
   const uniqueSources = [...new Set(sequence)];
-  const colorMap = {};
-  let colorIdx = 0;
-  let pdfColor = null;
+  const colorMap = COLOR_MAP;
   uniqueSources.forEach(src => {
-    let color;
-    if (src.toLowerCase().endsWith('.pdf')) {
-      if (!pdfColor) {
-        pdfColor = COLORS[colorIdx % COLORS.length];
-        colorIdx++;
-      }
-      color = pdfColor;
-    } else {
-      color = COLORS[colorIdx % COLORS.length];
-      colorIdx++;
-    }
-    colorMap[src] = color;
+    const color = colorMap[src] || '';
     const li = document.createElement('li');
     li.className = 'list-group-item';
     li.textContent = src;
-    li.style.backgroundColor = color;
+    if (color) li.style.backgroundColor = color;
     const url = SOURCE_URLS[src];
     if (url) {
       li.style.cursor = 'pointer';
@@ -121,7 +108,8 @@ function updateSources(ch, element) {
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
       }
       const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
+      const color = colorMap[src] || '';
+      node.style.backgroundColor = color;
       highlighted.push(node);
       if (markers[idx] && markers[idx].type === 'title') {
         idx = nextIdx;


### PR DESCRIPTION
## Summary
- Skip headings when extracting Word chapters
- Return HTML alongside DOCX results and log per-step colors
- Use stored HTML and log-provided colors for comparison view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b194de56d88323b3c609abb3b173cb