### PR TITLE
Highlight workflow steps in exported HTML

### DIFF
--- a/app.py
+++ b/app.py
@@ -579,19 +579,10 @@ def task_compare(task_id, job_id):
     job_dir = os.path.join(tdir, "jobs", job_id)
     docx_path = os.path.join(job_dir, "result.docx")
     log_path = os.path.join(job_dir, "log.json")
-    if not os.path.exists(docx_path) or not os.path.exists(log_path):
-        abort(404)
-
-    from spire.doc import Document, FileFormat
-
     html_name = "result.html"
     html_path = os.path.join(job_dir, html_name)
-    if not os.path.exists(html_path):
-        doc = Document()
-        doc.LoadFromFile(docx_path)
-        doc.HtmlExportOptions.ImageEmbedded = True
-        doc.SaveToFile(html_path, FileFormat.Html)
-        doc.Close()
+    if not (os.path.exists(docx_path) and os.path.exists(log_path) and os.path.exists(html_path)):
+        abort(404)
 
     chapter_sources = {}
     source_urls = {}

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -51,8 +51,41 @@ SUPPORTED_STEPS = {
 
 def boolish(v:str)->bool:
     return str(v).lower() in ["1","true","yes","y","on"]
+STEP_COLOR_HEX = {
+    "extract_pdf_chapter_to_table": "#ffb3ba",
+    "extract_word_all_content": "#baffc9",
+    "extract_word_chapter": "#bae1ff",
+    "insert_text": "#ffdfba",
+    "insert_numbered_heading": "#ffffba",
+    "insert_roman_heading": "#baffff",
+    "insert_bulleted_heading": "#f4baff",
+}
 
-def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
+
+def _hex_to_color(h: str):
+    if not h:
+        return None
+    h = h.lstrip("#")
+    if len(h) != 6:
+        return None
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+    return Color.FromRgb(r, g, b)
+
+
+def _color_new_content(section: Section, para_start: int, table_start: int, color: "Color"):
+    if color is None:
+        return
+    for i in range(para_start, section.Paragraphs.Count):
+        p = section.Paragraphs.get_Item(i)
+        p.Format.BackColor = color
+    for i in range(table_start, section.Tables.Count):
+        t = section.Tables.get_Item(i)
+        t.TableFormat.BackColor = color
+
+
+def run_workflow(steps: List[Dict[str, Any]], workdir: str) -> Dict[str, Any]:
     log = []
     output_doc = Document()
     section = output_doc.AddSection()
@@ -61,6 +94,8 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
         stype = step.get("type")
         params = step.get("params", {})
         log.append({"step": idx, "type": stype, "params": params})
+        para_start = section.Paragraphs.Count
+        table_start = section.Tables.Count
         try:
             if stype == "extract_pdf_chapter_to_table":
                 import zipfile
@@ -70,65 +105,82 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     raise RuntimeError("未提供 PDF ZIP 檔或路徑錯誤")
                 extract_dir = os.path.join(workdir, "pdfs_extracted")
                 os.makedirs(extract_dir, exist_ok=True)
-                with zipfile.ZipFile(zip_path, 'r') as zf:
+                with zipfile.ZipFile(zip_path, "r") as zf:
                     zf.extractall(extract_dir)
-                extract_pdf_chapter_to_table(extract_dir, target, output_doc=output_doc, section=section)
+                extract_pdf_chapter_to_table(
+                    extract_dir, target, output_doc=output_doc, section=section
+                )
 
             elif stype == "extract_word_all_content":
                 infile = params["input_file"]
-                extract_word_all_content(infile, output_image_path=os.path.join(workdir,"images"), output_doc=output_doc, section=section)
+                extract_word_all_content(
+                    infile,
+                    output_image_path=os.path.join(workdir, "images"),
+                    output_doc=output_doc,
+                    section=section,
+                )
 
             elif stype == "extract_word_chapter":
                 infile = params["input_file"]
-                tsec = params.get("target_chapter_section","")
-                use_title = boolish(params.get("target_title","false"))
-                title_text = params.get("target_title_section","")
+                tsec = params.get("target_chapter_section", "")
+                use_title = boolish(params.get("target_title", "false"))
+                title_text = params.get("target_title_section", "")
                 extract_word_chapter(
                     infile,
                     tsec,
                     target_title=use_title,
                     target_title_section=title_text,
-                    output_image_path=os.path.join(workdir,"images"),
+                    output_image_path=os.path.join(workdir, "images"),
                     output_doc=output_doc,
-                    section=section
+                    section=section,
                 )
 
             elif stype == "insert_text":
-                insert_text(section,
-                            params.get("text",""),
-                            align=params.get("align","left"),
-                            bold=boolish(params.get("bold","false")),
-                            font_size=float(params.get("font_size",12)),
-                            before_space=float(params.get("before_space",0)),
-                            after_space=float(params.get("after_space",6)),
-                            page_break_before=boolish(params.get("page_break_before","false")))
+                insert_text(
+                    section,
+                    params.get("text", ""),
+                    align=params.get("align", "left"),
+                    bold=boolish(params.get("bold", "false")),
+                    font_size=float(params.get("font_size", 12)),
+                    before_space=float(params.get("before_space", 0)),
+                    after_space=float(params.get("after_space", 6)),
+                    page_break_before=boolish(params.get("page_break_before", "false")),
+                )
 
             elif stype == "insert_numbered_heading":
-                insert_numbered_heading(section,
-                                        params.get("text",""),
-                                        level=int(params.get("level",0)),
-                                        bold=boolish(params.get("bold","true")),
-                                        font_size=float(params.get("font_size",14)))
+                insert_numbered_heading(
+                    section,
+                    params.get("text", ""),
+                    level=int(params.get("level", 0)),
+                    bold=boolish(params.get("bold", "true")),
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             elif stype == "insert_roman_heading":
-                insert_roman_heading(section,
-                                     params.get("text",""),
-                                     level=int(params.get("level",0)),
-                                     bold=boolish(params.get("bold","true")),
-                                     font_size=float(params.get("font_size",14)))
+                insert_roman_heading(
+                    section,
+                    params.get("text", ""),
+                    level=int(params.get("level", 0)),
+                    bold=boolish(params.get("bold", "true")),
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             elif stype == "insert_bulleted_heading":
-                insert_bulleted_heading(section,
-                                        params.get("text",""),
-                                        level=0,
-                                        bullet_char='·',
-                                        bold=True,
-                                        font_size=float(params.get("font_size",14)))
+                insert_bulleted_heading(
+                    section,
+                    params.get("text", ""),
+                    level=0,
+                    bullet_char="·",
+                    bold=True,
+                    font_size=float(params.get("font_size", 14)),
+                )
 
             else:
                 raise RuntimeError(f"Unknown step type: {stype}")
 
             log[-1]["status"] = "ok"
+            color = _hex_to_color(STEP_COLOR_HEX.get(stype, ""))
+            _color_new_content(section, para_start, table_start, color)
 
         except Exception as e:
             log[-1]["status"] = "error"
@@ -136,6 +188,9 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
 
     out_docx = os.path.join(workdir, "result.docx")
     output_doc.SaveToFile(out_docx, FileFormat.Docx)
+    out_html = os.path.join(workdir, "result.html")
+    output_doc.HtmlExportOptions.ImageEmbedded = True
+    output_doc.SaveToFile(out_html, FileFormat.Html)
     output_doc.Close()
 
     out_log = os.path.join(workdir, "log.json")
@@ -143,4 +198,4 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
         import json
         json.dump(log, f, ensure_ascii=False, indent=2)
 
-    return {"result_docx": out_docx, "log": out_log, "log_json": log}
+    return {"result_docx": out_docx, "result_html": out_html, "log": out_log, "log_json": log}


### PR DESCRIPTION
## Summary
- Save an HTML version of workflow output during execution and assign a unique background color to content from each step
- Update compare page to use the pre-generated HTML instead of converting from the Word document

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b50f4f3d94832390abe5c24d2127b7