### PR TITLE
Track chapter titles for color‑coded comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -573,6 +573,28 @@ def task_translate(task_id, job_id):
     )
 
 
+def build_chapter_segments(entries):
+    chapter_segments = {}
+    current = None
+    for entry in entries:
+        stype = entry.get("type")
+        params = entry.get("params", {})
+        if stype == "insert_roman_heading":
+            current = params.get("text", "")
+            chapter_segments.setdefault(current, [])
+        elif stype == "extract_word_chapter":
+            infile = params.get("input_file", "")
+            base = os.path.basename(infile)
+            for t in entry.get("titles", []):
+                chapter_segments.setdefault(current or "未分類", []).append({
+                    "index": t.get("index", 0),
+                    "source": base,
+                })
+    for segs in chapter_segments.values():
+        segs.sort(key=lambda x: x["index"])
+    return chapter_segments
+
+
 @app.get("/tasks/<task_id>/compare/<job_id>")
 def task_compare(task_id, job_id):
     tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
@@ -666,6 +688,7 @@ def task_compare(task_id, job_id):
                     "task_view_file", task_id=task_id, job_id=job_id, filename=converted_docx[base]
                 )
 
+    chapter_segments = build_chapter_segments(entries)
     chapters = list(chapter_sources.keys())
     html_url = url_for("task_view_file", task_id=task_id, job_id=job_id, filename=html_name)
     return render_template(
@@ -673,6 +696,7 @@ def task_compare(task_id, job_id):
         html_url=html_url,
         chapters=chapters,
         chapter_sources=chapter_sources,
+        chapter_segments=chapter_segments,
         source_urls=source_urls,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
         save_url=url_for("task_compare_save", task_id=task_id, job_id=job_id),

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -202,6 +202,8 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
     nodes.put(input_doc)
     image_count = [1]
     capture_mode = False
+    chapter_titles = []
+    para_index = section.Paragraphs.Count if section else 0
 
     def add_table_to_section(sec, table):
         try:
@@ -235,6 +237,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    chapter_titles.append({"title": paragraph_text, "index": para_index})
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
@@ -250,6 +253,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                                     para.Format.HorizontalAlignment = HorizontalAlignment.Center
                             else:
                                 para.AppendText(part)
+                    para_index += 1
             elif isinstance(child, Table) and capture_mode:
                 add_table_to_section(section, child)
             elif isinstance(child, ICompositeObject):
@@ -259,6 +263,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
         output_doc.SaveToFile("word_chapter_result.docx", FileFormat.Docx)
     input_doc.Close()
     print(f"以將章節 {target_chapter_section} 擷取")
+    return chapter_titles
 
 def center_table_figure_paragraphs(input_file: str) -> bool:
     pattern = re.compile(r'^\s*(Table|Figure)\s+', re.IGNORECASE)

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -83,7 +83,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                 tsec = params.get("target_chapter_section","")
                 use_title = boolish(params.get("target_title","false"))
                 title_text = params.get("target_title_section","")
-                extract_word_chapter(
+                titles = extract_word_chapter(
                     infile,
                     tsec,
                     target_title=use_title,
@@ -92,6 +92,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     output_doc=output_doc,
                     section=section
                 )
+                log[-1]["titles"] = titles
 
             elif stype == "insert_text":
                 insert_text(section,

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -34,6 +34,7 @@
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
 const SOURCE_URLS = {{ source_urls|tojson }};
+const CHAPTER_SEGMENTS = {{ chapter_segments|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
 const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
@@ -93,42 +94,18 @@ function updateSources(ch, element) {
     list.appendChild(li);
   });
 
-  if (element) {
-    let node = element.nextElementSibling;
-    let idx = 0;
-    const markers = sequence.map(src => {
-      const title = src.match(/標題\s*(.+)/);
-      if (title) return {type: 'title', value: title[1]};
-      const sec = src.match(/章節\s*([\d\.]+)/);
-      return sec ? {type: 'section', value: sec[1]} : null;
-    });
-    const findNextMarkerIdx = from => {
-      for (let i = from + 1; i < markers.length; i++) {
-        if (markers[i]) return i;
+  const segments = CHAPTER_SEGMENTS[ch] || [];
+  if (segments.length) {
+    const paras = Array.from(doc.body.children);
+    for (let i = 0; i < segments.length; i++) {
+      const start = segments[i].index;
+      const end = i + 1 < segments.length ? segments[i + 1].index : paras.length;
+      const src = segments[i].source;
+      for (let j = start; j < end; j++) {
+        if (!paras[j]) break;
+        paras[j].style.backgroundColor = colorMap[src];
+        highlighted.push(paras[j]);
       }
-      return -1;
-    };
-    let nextIdx = findNextMarkerIdx(0);
-    let nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
-    while (node && !CHAPTER_SET.has(node.textContent.trim())) {
-      const text = node.textContent.trim();
-      if (nextMarker && highlighted.length && (
-          (nextMarker.type === 'section' && text.startsWith(nextMarker.value)) ||
-          (nextMarker.type === 'title' && text.includes(nextMarker.value))
-        )) {
-        idx = nextIdx;
-        nextIdx = findNextMarkerIdx(idx);
-        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
-      }
-      const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
-      highlighted.push(node);
-      if (markers[idx] && markers[idx].type === 'title') {
-        idx = nextIdx;
-        nextIdx = findNextMarkerIdx(idx);
-        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
-      }
-      node = node.nextElementSibling;
     }
   }
 }

--- a/tests/test_compare_segments.py
+++ b/tests/test_compare_segments.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import build_chapter_segments
+
+def test_build_chapter_segments():
+    entries = [
+        {"type": "insert_roman_heading", "params": {"text": "Chapter A"}},
+        {"type": "extract_word_chapter", "params": {"input_file": os.path.join('dir','a.docx')}, "titles": [{"title": "1.1", "index": 3}]},
+        {"type": "extract_word_chapter", "params": {"input_file": os.path.join('dir','b.docx')}, "titles": [{"title": "1.2", "index": 7}]}
+    ]
+    segs = build_chapter_segments(entries)
+    assert "Chapter A" in segs
+    assert segs["Chapter A"] == [
+        {"index": 3, "source": "a.docx"},
+        {"index": 7, "source": "b.docx"},
+    ]


### PR DESCRIPTION
## Summary
- capture chapter titles and paragraph indices when extracting Word sections
- log chapter title metadata during workflows and expose it to comparison UI
- color paragraphs by recorded chapter segments and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5177cd49c8323b11dcf7d9cc0b284