### PR TITLE
Preserve source highlighting after removing chapter titles

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -235,6 +235,9 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    marker_para = section.AddParagraph()
+                    marker_run = marker_para.AppendText(paragraph_text)
+                    marker_run.CharacterFormat.Hidden = True
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -120,18 +120,13 @@ function updateSources(ch, element) {
         nextIdx = findNextMarkerIdx(idx);
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
       }
-      const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
-      highlighted.push(node);
-      if (markers[idx] && markers[idx].type === 'title') {
-        idx = nextIdx;
-        nextIdx = findNextMarkerIdx(idx);
-        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+        const src = sequence[idx] || sequence[sequence.length - 1];
+        node.style.backgroundColor = colorMap[src];
+        highlighted.push(node);
+        node = node.nextElementSibling;
       }
-      node = node.nextElementSibling;
     }
   }
-}
 
 const iframe = document.getElementById('htmlFrame');
 let doc;


### PR DESCRIPTION
## Summary
- Insert hidden paragraph markers for matched sections in `extract_word_chapter` so section titles remain invisible yet available for source highlighting.
- Simplify compare view highlighting logic by removing premature index shifts tied to title markers.

## Testing
- `python -m py_compile modules/Extract_AllFile_to_FinalWord.py`


------
https://chatgpt.com/codex/tasks/task_e_68b51c4e762c8323aa497141e03bf1a5