### PR TITLE
Preserve source highlighting after removing chapter titles

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import json
 import zipfile
+import re
 from datetime import datetime
 from flask import (
     Flask,
@@ -18,6 +19,7 @@ from modules.workflow import SUPPORTED_STEPS, run_workflow
 from modules.Extract_AllFile_to_FinalWord import (
     center_table_figure_paragraphs,
     apply_basic_style,
+    remove_hidden_runs,
 )
 from modules.translate_with_bedrock import translate_file
 from modules.file_mover import move_files
@@ -592,6 +594,7 @@ def task_compare(task_id, job_id):
         doc.HtmlExportOptions.ImageEmbedded = True
         doc.SaveToFile(html_path, FileFormat.Html)
         doc.Close()
+        remove_hidden_runs(docx_path)
 
     chapter_sources = {}
     source_urls = {}
@@ -690,6 +693,13 @@ def task_compare_save(task_id, job_id):
         html_content = data.get("html", "")
     if not html_content:
         return "缺少內容", 400
+    html_content = re.sub(
+        r'<span[^>]*style="[^"]*display\s*:\s*none[^"]*"[^>]*>.*?</span>',
+        '',
+        html_content,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    html_content = re.sub(r'<p[^>]*>\s*</p>', '', html_content, flags=re.IGNORECASE)
     html_path = os.path.join(job_dir, "result.html")
     with open(html_path, "w", encoding="utf-8") as f:
         f.write(html_content)
@@ -699,7 +709,9 @@ def task_compare_save(task_id, job_id):
     doc.LoadFromFile(html_path, FileFormat.Html)
     doc.SaveToFile(os.path.join(job_dir, "result.docx"), FileFormat.Docx)
     doc.Close()
-    apply_basic_style(os.path.join(job_dir, "result.docx"))
+    result_docx = os.path.join(job_dir, "result.docx")
+    remove_hidden_runs(result_docx)
+    apply_basic_style(result_docx)
     return "OK"
 
 

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -235,6 +235,9 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    marker_para = section.AddParagraph()
+                    marker_run = marker_para.AppendText(paragraph_text)
+                    marker_run.CharacterFormat.Hidden = True
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
@@ -304,7 +307,7 @@ def center_table_figure_paragraphs(input_file: str) -> bool:
 
 
 def _iter_paragraphs(parent):
-    """Yield paragraphs in parent recursively, including those in tables."""
+    """Yield paragraphs in parent recursively, including those in tables.""" 
     if hasattr(parent, "paragraphs"):
         for p in parent.paragraphs:
             yield p
@@ -313,6 +316,23 @@ def _iter_paragraphs(parent):
             for row in table.rows:
                 for cell in row.cells:
                     yield from _iter_paragraphs(cell)
+
+def remove_hidden_runs(input_file: str) -> bool:
+    """Remove runs marked as hidden and drop empty paragraphs."""
+    try:
+        doc = DocxDocument(input_file)
+        for para in list(_iter_paragraphs(doc)):
+            to_remove = [run for run in para.runs if run.font.hidden]
+            for run in to_remove:
+                para._element.remove(run._element)
+            if not para.text.strip():
+                p = para._element
+                p.getparent().remove(p)
+        doc.save(input_file)
+        return True
+    except Exception as e:
+        print(f"錯誤：移除隱藏文字 {input_file} 時出錯: {str(e)}")
+        return False
 
 
 def apply_basic_style(

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -120,18 +120,13 @@ function updateSources(ch, element) {
         nextIdx = findNextMarkerIdx(idx);
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
       }
-      const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
-      highlighted.push(node);
-      if (markers[idx] && markers[idx].type === 'title') {
-        idx = nextIdx;
-        nextIdx = findNextMarkerIdx(idx);
-        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+        const src = sequence[idx] || sequence[sequence.length - 1];
+        node.style.backgroundColor = colorMap[src];
+        highlighted.push(node);
+        node = node.nextElementSibling;
       }
-      node = node.nextElementSibling;
     }
   }
-}
 
 const iframe = document.getElementById('htmlFrame');
 let doc;


### PR DESCRIPTION
## Summary
- Add `remove_hidden_runs` utility to drop hidden title paragraphs so result Word documents omit chapter headers.
- Strip `display:none` markers from compare HTML and clean the docx after HTML export to keep titles hidden while retaining source highlighting.

## Testing
- `python -m py_compile modules/Extract_AllFile_to_FinalWord.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b51c4e762c8323aa497141e03bf1a5