### PR TITLE
Preserve source highlighting after removing chapter titles

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -120,18 +120,13 @@ function updateSources(ch, element) {
         nextIdx = findNextMarkerIdx(idx);
         nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
       }
-      const src = sequence[idx] || sequence[sequence.length - 1];
-      node.style.backgroundColor = colorMap[src];
-      highlighted.push(node);
-      if (markers[idx] && markers[idx].type === 'title') {
-        idx = nextIdx;
-        nextIdx = findNextMarkerIdx(idx);
-        nextMarker = nextIdx !== -1 ? markers[nextIdx] : null;
+        const src = sequence[idx] || sequence[sequence.length - 1];
+        node.style.backgroundColor = colorMap[src];
+        highlighted.push(node);
+        node = node.nextElementSibling;
       }
-      node = node.nextElementSibling;
     }
   }
-}
 
 const iframe = document.getElementById('htmlFrame');
 let doc;


### PR DESCRIPTION
## Summary
- Strip hidden chapter titles from generated DOCX files immediately after workflow runs so direct downloads no longer show titles
- Drop hidden title runs in both ad-hoc and saved flow execution paths before styling

## Testing
- `python -m py_compile modules/Extract_AllFile_to_FinalWord.py modules/workflow.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b51c4e762c8323aa497141e03bf1a5