### PR TITLE
Add move files workflow step

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,7 +300,7 @@ def upload_task_file(task_id):
     return redirect(url_for("task_detail", task_id=task_id))
 
 def gather_available_files(files_dir):
-    mapping = {"docx": [], "pdf": [], "zip": []}
+    mapping = {"docx": [], "pdf": [], "zip": [], "dir": []}
     for rel in list_files(files_dir):
         ext = os.path.splitext(rel)[1].lower()
         if ext == ".docx":
@@ -309,6 +309,7 @@ def gather_available_files(files_dir):
             mapping["pdf"].append(rel)
         elif ext == ".zip":
             mapping["zip"].append(rel)
+    mapping["dir"] = list_dirs(files_dir)
     return mapping
 
 

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -10,6 +10,7 @@ from .Extract_AllFile_to_FinalWord import (
     extract_word_all_content,
     extract_word_chapter
 )
+from .file_mover import move_files
 
 SUPPORTED_STEPS = {
     "extract_pdf_chapter_to_table": {
@@ -46,6 +47,15 @@ SUPPORTED_STEPS = {
         "label": "插入項目符號標題",
         "inputs": ["text", "font_size"],
         "accepts": {"text":"text","font_size":"float"}
+    },
+    "move_files": {
+        "label": "移動檔案",
+        "inputs": ["source_dir", "dest_dir", "keywords"],
+        "accepts": {
+            "source_dir": "file:dir",
+            "dest_dir": "file:dir",
+            "keywords": "text"
+        }
     }
 }
 
@@ -124,6 +134,15 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                                         bullet_char='·',
                                         bold=True,
                                         font_size=float(params.get("font_size",14)))
+
+            elif stype == "move_files":
+                keywords = [k.strip() for k in params.get("keywords", "").split(",") if k.strip()]
+                moved = move_files(
+                    params.get("source_dir", ""),
+                    params.get("dest_dir", ""),
+                    keywords,
+                )
+                log[-1]["moved_files"] = moved
 
             else:
                 raise RuntimeError(f"Unknown step type: {stype}")

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -187,6 +187,9 @@ function addStep(typeKey, preset={}, refSid=null, position='end'){
     if (k === "text") label = "輸入文字";
     if (k === "align") label = "對齊方式";
     if (k === "bold") label = "粗體";
+    if (k === "source_dir") label = "來源資料夾";
+    if (k === "dest_dir") label = "目的資料夾";
+    if (k === "keywords") label = "關鍵字（逗號分隔）";
 
     const val = preset[k] || "";
     if (accept === "text"){
@@ -241,9 +244,16 @@ function addStep(typeKey, preset={}, refSid=null, position='end'){
       }
     } else if (accept.startsWith("file")){
       const ext = accept.split(":")[1];
-      const options = (AVAILABLE_FILES[ext] || []).map(f => `<option value="${f}" ${val===f?"selected": ""}>${f}</option>`).join("");
-      body += `<div class="col-md-6"><label class="form-label">${label}</label>
-               <select class="form-select" name="step_${sid}_${k}">${options}</select></div>`;
+      if (ext === "dir") {
+        const options = (AVAILABLE_FILES[ext] || []).map(f => `<option value="${f}"></option>`).join("");
+        body += `<div class="col-md-6"><label class="form-label">${label}</label>
+                 <input class="form-control" name="step_${sid}_${k}" list="list_${sid}_${k}" value="${val}" placeholder="${label}">
+                 <datalist id="list_${sid}_${k}">${options}</datalist></div>`;
+      } else {
+        const options = (AVAILABLE_FILES[ext] || []).map(f => `<option value="${f}" ${val===f?"selected": ""}>${f}</option>`).join("");
+        body += `<div class="col-md-6"><label class="form-label">${label}</label>
+                 <select class="form-select" name="step_${sid}_${k}">${options}</select></div>`;
+      }
     } else if (k === "align"){
       body += `<div class="col-md-3"><label class="form-label">對齊</label>
                <select class="form-select" name="step_${sid}_align">

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,9 @@ function addStep(typeKey){
     if (k === "target_section") label = "章節編號（例如 6.12.1）";
     if (k === "target_chapter_section") label = "章節編號（例如 6.12.1）";
     if (k === "target_title_section") label = "章節標題（完整比對）";
+    if (k === "source_dir") label = "來源資料夾";
+    if (k === "dest_dir") label = "目的資料夾";
+    if (k === "keywords") label = "關鍵字（逗號分隔）";
 
     if (accept === "text"){
       body += `<div class="col-md-6"><label class="form-label">${label}</label>
@@ -114,8 +117,14 @@ function addStep(typeKey){
                  <input class="form-control" type="number" step="any" name="step_${sid}_${k}" placeholder="${label}"></div>`;
       }
     } else if (accept.startsWith("file")){
-      body += `<div class="col-md-6"><label class="form-label">${label}</label>
-               <input class="form-control" type="file" name="step_${sid}_${k}"></div>`;
+      const ext = accept.split(":")[1];
+      if (ext === "dir") {
+        body += `<div class="col-md-6"><label class="form-label">${label}</label>
+                 <input class="form-control" name="step_${sid}_${k}" placeholder="${label}"></div>`;
+      } else {
+        body += `<div class="col-md-6"><label class="form-label">${label}</label>
+                 <input class="form-control" type="file" name="step_${sid}_${k}"></div>`;
+      }
     } else if (k === "align"){
       body += `<div class="col-md-3"><label class="form-label">對齊</label>
                <select class="form-select" name="step_${sid}_align">


### PR DESCRIPTION
## Summary
- add `move_files` step with source/dest folder and keyword inputs
- support directory selection in flow builder templates
- expose available directories for file steps

## Testing
- `pytest`
- `python -m py_compile app.py modules/workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68b56b6f790083238f0e1b400b712e67