### PR TITLE
Prompt before overwriting files during copy

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,7 +128,12 @@ def task_copy_files(task_id):
                 try:
                     src = _safe_path(source_rel)
                     dest = _safe_path(dest_rel)
-                    copied = copy_files(src, dest, keywords)
+                    copied = copy_files(
+                        src,
+                        dest,
+                        keywords,
+                        overwrite_prompt=lambda _p: True,
+                    )
                     message = f"已複製 {len(copied)} 個檔案"
                 except ValueError:
                     message = "資料夾名稱不合法"

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -141,6 +141,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     params.get("source_dir", ""),
                     params.get("dest_dir", ""),
                     keywords,
+                    overwrite_prompt=lambda _p: True,
                 )
                 log[-1]["copied_files"] = copied
 


### PR DESCRIPTION
## Summary
- ask for confirmation before replacing existing files in `copy_files`
- ensure web and workflow copies overwrite automatically via callback

## Testing
- `python -m py_compile modules/file_copier.py app.py modules/workflow.py`
- `python modules/file_copier.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68b5b7d4db3c83238ab56bfd912febaa