### PR TITLE
Prompt before overwriting files

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,7 +128,9 @@ def task_copy_files(task_id):
                 try:
                     src = _safe_path(source_rel)
                     dest = _safe_path(dest_rel)
-                    copied = copy_files(src, dest, keywords)
+                    copied = copy_files(
+                        src, dest, keywords, confirm_overwrite=False
+                    )
                     message = f"已複製 {len(copied)} 個檔案"
                 except ValueError:
                     message = "資料夾名稱不合法"

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -141,6 +141,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     params.get("source_dir", ""),
                     params.get("dest_dir", ""),
                     keywords,
+                    confirm_overwrite=False,
                 )
                 log[-1]["copied_files"] = copied
 


### PR DESCRIPTION
## Summary
- prompt user before overwriting files when copying
- allow disabling prompt to auto-rename conflicts
- update app and workflow to copy without interactive prompts

## Testing
- `python -m py_compile modules/file_copier.py app.py modules/workflow.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba4cc2188323a6b743ab7a89bfa8