### PR TITLE
Overwrite existing files during copy

### DIFF
--- a/modules/file_copier.py
+++ b/modules/file_copier.py
@@ -7,7 +7,8 @@ def copy_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
     """Copy files whose names contain all provided keywords.
 
     Keywords are matched case-insensitively. A file is copied only when its
-    name contains *all* of the specified keywords.
+    name contains *all* of the specified keywords. If a file with the same
+    name already exists in the destination directory, it will be overwritten.
 
     Parameters
     ----------
@@ -36,11 +37,6 @@ def copy_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
             if all(k in lower_name for k in lowered_keywords):
                 src_path = os.path.join(root, name)
                 dest_path = os.path.join(destination, name)
-                base, ext = os.path.splitext(name)
-                count = 1
-                while os.path.exists(dest_path):
-                    dest_path = os.path.join(destination, f"{base}_{count}{ext}")
-                    count += 1
                 shutil.copy2(src_path, dest_path)
                 copied_files.append(dest_path)
     return copied_files

--- a/tests/test_file_copier.py
+++ b/tests/test_file_copier.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from modules.file_copier import copy_files
+
+
+def test_copy_files_overwrite(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.mkdir()
+    dest.mkdir()
+    file_path = src / "example.txt"
+    file_path.write_text("first")
+
+    copy_files(str(src), str(dest), ["example"])
+    dest_file = dest / "example.txt"
+    assert dest_file.read_text() == "first"
+
+    file_path.write_text("second")
+    copy_files(str(src), str(dest), ["example"])
+    assert dest_file.read_text() == "second"


### PR DESCRIPTION
## Summary
- Overwrite destination files when copying instead of renaming
- Add unit test verifying file overwrite behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbe9545c8323b765de00822ec1d0