### PR TITLE
feat: confirm before running flows that copy files

### DIFF
--- a/app.py
+++ b/app.py
@@ -301,14 +301,22 @@ def flow_builder(task_id):
         if fn.endswith(".json"):
             path = os.path.join(flow_dir, fn)
             created = datetime.fromtimestamp(os.path.getmtime(path)).strftime("%Y-%m-%d %H:%M")
+            has_copy = False
             try:
                 with open(path, "r", encoding="utf-8") as f:
                     data = json.load(f)
                 if isinstance(data, dict):
+                    steps_data = data.get("steps", [])
                     created = data.get("created", created)
+                else:
+                    steps_data = data
+                has_copy = any(
+                    isinstance(s, dict) and s.get("type") == "copy_files"
+                    for s in steps_data
+                )
             except Exception:
                 pass
-            flows.append({"name": os.path.splitext(fn)[0], "created": created})
+            flows.append({"name": os.path.splitext(fn)[0], "created": created, "has_copy": has_copy})
     preset = None
     center_titles = True
     loaded_name = request.args.get("flow")

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -80,7 +80,7 @@
       <td>{{ f.name }}</td>
       <td>{{ f.created }}</td>
       <td>
-        <form action="{{ url_for('execute_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline">
+        <form action="{{ url_for('execute_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline" {% if f.has_copy %}onsubmit="return confirm('此流程包含複製檔案步驟，確定要執行嗎？');"{% endif %}>
           <button class="btn btn-sm btn-outline-success">執行</button>
         </form>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('flow_builder', task_id=task.id, flow=f.name) }}">編輯</a>
@@ -131,6 +131,14 @@ flowForm.addEventListener('submit', (e) => {
     e.preventDefault();
     alert('請輸入流程名稱');
     return;
+  }
+  if (action === 'run') {
+    const hasCopy = Array.from(flowForm.querySelectorAll('input[name$="_type"]'))
+      .some(el => el.value === 'copy_files');
+    if (hasCopy && !confirm('此流程包含複製檔案步驟，確定要執行嗎？')) {
+      e.preventDefault();
+      return;
+    }
   }
   isDirty = false;
 });


### PR DESCRIPTION
## Summary
- flag saved flows with copy-files steps and warn before executing
- prompt before executing ad-hoc flows that copy files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b64759872083238cac6d67eebc00d4