### PR TITLE
feat: renumber figures and tables in merged Word output

### DIFF
--- a/modules/postprocess.py
+++ b/modules/postprocess.py
@@ -1,0 +1,62 @@
+import re
+from typing import Dict
+from docx import Document
+
+
+def _replace_run_text(paragraph, old: str, new: str) -> bool:
+    """Replace first occurrence of old in the paragraph runs with new.
+    Returns True if replaced."""
+    for run in paragraph.runs:
+        if old in run.text:
+            run.text = run.text.replace(old, new, 1)
+            return True
+    return False
+
+
+def renumber_figures_tables(docx_path: str) -> None:
+    """Renumber figure and table captions and update references in-place.
+
+    Parameters
+    ----------
+    docx_path: str
+        Path to the Word document to process. The file is modified in-place.
+    """
+    doc = Document(docx_path)
+
+    fig_map: Dict[str, str] = {}
+    table_map: Dict[str, str] = {}
+    fig_counter = 1
+    table_counter = 1
+    caption_pattern = re.compile(r'^(Figure|Fig\.?|Table)\s*(\d+)', re.IGNORECASE)
+
+    # First pass: renumber captions and build mapping of old->new numbers
+    for para in doc.paragraphs:
+        match = caption_pattern.match(para.text.strip())
+        if not match:
+            continue
+        label, old_num = match.group(1), match.group(2)
+        if label.lower().startswith('fig'):
+            fig_map[old_num] = str(fig_counter)
+            _replace_run_text(para, old_num, str(fig_counter))
+            fig_counter += 1
+        else:
+            table_map[old_num] = str(table_counter)
+            _replace_run_text(para, old_num, str(table_counter))
+            table_counter += 1
+
+    # Second pass: update in-text references using the mappings
+    ref_pattern = re.compile(r'(Figure|Fig\.?|Table)\s*(\d+)', re.IGNORECASE)
+    for para in doc.paragraphs:
+        for run in para.runs:
+            def _repl(m: re.Match) -> str:
+                label, num = m.group(1), m.group(2)
+                if re.match(r'Fig\.?|Figure', label, re.IGNORECASE):
+                    new_num = fig_map.get(num)
+                else:
+                    new_num = table_map.get(num)
+                return f"{label} {new_num}" if new_num else m.group(0)
+
+            new_text = ref_pattern.sub(_repl, run.text)
+            run.text = new_text
+
+    doc.save(docx_path)

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -157,6 +157,10 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
     output_doc.SaveToFile(out_docx, FileFormat.Docx)
     output_doc.Close()
 
+    # Post-process the generated document to ensure figure/table numbering
+    from .postprocess import renumber_figures_tables
+    renumber_figures_tables(out_docx)
+
     out_log = os.path.join(workdir, "log.json")
     with open(out_log, "w", encoding="utf-8") as f:
         import json

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,22 @@
+import os
+from docx import Document
+from modules.postprocess import renumber_figures_tables
+
+
+def test_renumber_figures_tables(tmp_path):
+    doc_path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("Figure 5: A cat")
+    doc.add_paragraph("See Figure 5 for details. Table 3 shows numbers.")
+    doc.add_paragraph("Table 3: Data table")
+    doc.add_paragraph("Another reference to Table 3 and Figure 5.")
+    doc.save(doc_path)
+
+    renumber_figures_tables(str(doc_path))
+
+    processed = Document(doc_path)
+    texts = [p.text for p in processed.paragraphs]
+    assert texts[0].startswith("Figure 1")
+    assert "Figure 1" in texts[1]
+    assert texts[2].startswith("Table 1")
+    assert "Table 1" in texts[3]


### PR DESCRIPTION
## Summary
- add post-processing utility to renumber figure and table captions and their in-text references
- invoke renumbering after workflow generates the final document
- test renumbering to ensure captions and references update consistently

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9908eb083238350d4a7d0aff1d3