### PR TITLE
feat: renumber figures and tables in generated Word docs

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from werkzeug.utils import secure_filename
 from modules.workflow import SUPPORTED_STEPS, run_workflow
 from modules.Extract_AllFile_to_FinalWord import (
     center_table_figure_paragraphs,
+    renumber_figures_tables,
     apply_basic_style,
     remove_hidden_runs,
 )
@@ -417,6 +418,7 @@ def run_flow(task_id):
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
     result_path = os.path.join(job_dir, "result.docx")
+    renumber_figures_tables(result_path)
     if center_titles:
         center_table_figure_paragraphs(result_path)
     remove_hidden_runs(result_path)
@@ -463,6 +465,7 @@ def execute_flow(task_id, flow_name):
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
     result_path = os.path.join(job_dir, "result.docx")
+    renumber_figures_tables(result_path)
     if center_titles:
         center_table_figure_paragraphs(result_path)
     remove_hidden_runs(result_path)

--- a/tests/test_renumber_figures_tables.py
+++ b/tests/test_renumber_figures_tables.py
@@ -1,0 +1,21 @@
+import os
+from docx import Document
+from modules.Extract_AllFile_to_FinalWord import renumber_figures_tables
+
+def test_renumber_figures_tables(tmp_path):
+    doc = Document()
+    doc.add_paragraph("Figure 5. Sample figure")
+    doc.add_paragraph("As shown in Figure 5 above.")
+    doc.add_paragraph("Table 10: Sample table")
+    doc.add_paragraph("Refer to Table 10 for details.")
+    file_path = tmp_path / "test.docx"
+    doc.save(file_path)
+
+    assert renumber_figures_tables(str(file_path))
+
+    updated = Document(file_path)
+    texts = [p.text for p in updated.paragraphs]
+    assert texts[0].startswith("Figure 1")
+    assert "Figure 1" in texts[1]
+    assert texts[2].startswith("Table 1")
+    assert "Table 1" in texts[3]


### PR DESCRIPTION
## Summary
- add post-processing step to renumber figure and table captions and update in-text references
- integrate renumbering after workflow execution
- cover figure/table renumbering logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6fca3e9c483239729c643da2c628e