### PR TITLE
Refactor figure/table renumbering into mapping and update passes

### DIFF
--- a/modules/Edit_Word.py
+++ b/modules/Edit_Word.py
@@ -157,6 +157,15 @@ def renumber_figures_tables(
 ) -> None:
     """Renumber figures and tables and update cross-references.
 
+    The procedure performs two passes to avoid losing the original
+    numbering information:
+
+    1. Scan the document to build mappings from existing figure/table
+       numbers to their new values **and** record all in-text references
+       without modifying any text.
+    2. Apply those mappings to every paragraph so that captions and
+       cross-references are updated in one sweep.
+
     Parameters
     ----------
     doc : Document
@@ -184,19 +193,25 @@ def renumber_figures_tables(
 
     figure_map = {}
     table_map = {}
+    figure_refs = set()
+    table_refs = set()
+
+    numbering_scope = numbering_scope.lower()
+
+    # -------------------------------------
+    # Pass 1: build caption map and gather references
+    # -------------------------------------
+    fig_counter_global = figure_start
+    tab_counter_global = table_start
 
     for sec_idx in range(doc.Sections.Count):
         section = doc.Sections.get_Item(sec_idx)
         fig_counter = figure_start
         tab_counter = table_start
-        if numbering_scope.lower() == "global" and sec_idx > 0:
-            fig_counter = figure_map.get("__next__", figure_start)
-            tab_counter = table_map.get("__next__", table_start)
 
         for p_idx in range(section.Paragraphs.Count):
             para = section.Paragraphs.get_Item(p_idx)
 
-            # Build paragraph text for caption detection
             para_text = "".join(
                 para.ChildObjects.get_Item(i).Text
                 for i in range(para.ChildObjects.Count)
@@ -206,39 +221,73 @@ def renumber_figures_tables(
             m = caption_regex.match(para_text.strip())
             if m:
                 prefix, sep, old_num = m.group(1), m.group(2), m.group(3)
-                if prefix.lower().startswith("f"):
-                    new_num = f"{sec_idx + 1}-{fig_counter}" if numbering_scope.lower() == "per-section" else str(fig_counter)
-                    figure_map[old_num] = new_num
-                    fig_counter += 1
-                else:
-                    new_num = f"{sec_idx + 1}-{tab_counter}" if numbering_scope.lower() == "per-section" else str(tab_counter)
-                    table_map[old_num] = new_num
-                    tab_counter += 1
-
-            def repl(match: re.Match) -> str:
-                prefix, sep, old = match.group(1), match.group(2), match.group(3)
                 lower = prefix.lower()
                 if lower.startswith("f"):
-                    new = figure_map.get(old)
-                    if new:
-                        return f"{prefix}{sep}{new}"
+                    if numbering_scope == "per-section":
+                        new_num = f"{sec_idx + 1}-{fig_counter}"
+                        fig_counter += 1
+                    else:
+                        new_num = str(fig_counter_global)
+                        fig_counter_global += 1
+                    figure_map[old_num] = new_num
                 else:
-                    new = table_map.get(old)
-                    if new:
-                        return f"{prefix}{sep}{new}"
-                return match.group(0)
+                    if numbering_scope == "per-section":
+                        new_num = f"{sec_idx + 1}-{tab_counter}"
+                        tab_counter += 1
+                    else:
+                        new_num = str(tab_counter_global)
+                        tab_counter_global += 1
+                    table_map[old_num] = new_num
 
-            # Replace text in each run
+            for ref_prefix, ref_sep, ref_num in ref_regex.findall(para_text):
+                if ref_prefix.lower().startswith("f"):
+                    figure_refs.add(ref_num)
+                else:
+                    table_refs.add(ref_num)
+
+    unmatched_fig_refs = figure_refs - set(figure_map.keys())
+    unmatched_tab_refs = table_refs - set(table_map.keys())
+    if unmatched_fig_refs:
+        print(f"Warning: figure references with no matching caption: {sorted(unmatched_fig_refs)}")
+    if unmatched_tab_refs:
+        print(f"Warning: table references with no matching caption: {sorted(unmatched_tab_refs)}")
+
+    # -----------------------------------
+    # Pass 2: update captions and references
+    # -----------------------------------
+    def cap_repl(match: re.Match) -> str:
+        prefix, sep, old = match.group(1), match.group(2), match.group(3)
+        lower = prefix.lower()
+        if lower.startswith("f"):
+            new = figure_map.get(old)
+        else:
+            new = table_map.get(old)
+        if new:
+            return f"{prefix}{sep}{new}"
+        return match.group(0)
+
+    def ref_repl(match: re.Match) -> str:
+        prefix, sep, old = match.group(1), match.group(2), match.group(3)
+        lower = prefix.lower()
+        if lower.startswith("f"):
+            new = figure_map.get(old)
+        else:
+            new = table_map.get(old)
+        if new:
+            return f"{prefix}{sep}{new}"
+        return match.group(0)
+
+    for sec_idx in range(doc.Sections.Count):
+        section = doc.Sections.get_Item(sec_idx)
+        for p_idx in range(section.Paragraphs.Count):
+            para = section.Paragraphs.get_Item(p_idx)
             for r_idx in range(para.ChildObjects.Count):
                 child = para.ChildObjects.get_Item(r_idx)
                 if isinstance(child, TextRange):
-                    new_text = ref_regex.sub(repl, child.Text)
+                    new_text = caption_regex.sub(cap_repl, child.Text)
+                    new_text = ref_regex.sub(ref_repl, new_text)
                     if new_text != child.Text:
                         child.Text = new_text
-
-        if numbering_scope.lower() == "global":
-            figure_map["__next__"] = fig_counter
-            table_map["__next__"] = tab_counter
 
     # Update any generated tables/lists if available
     try:


### PR DESCRIPTION
## Summary
- Record figure and table references before any renumbering occurs
- Apply renumbered captions and in-text updates in a unified second pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7af71965c83238521cc14d678ea62