### PR TITLE
Add automatic figure/table renumbering

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from modules.Extract_AllFile_to_FinalWord import (
     apply_basic_style,
     remove_hidden_runs,
 )
+from modules.Edit_Word import renumber_figures_tables_file
 from modules.translate_with_bedrock import translate_file
 from modules.file_copier import copy_files
 
@@ -417,6 +418,7 @@ def run_flow(task_id):
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
     result_path = os.path.join(job_dir, "result.docx")
+    renumber_figures_tables_file(result_path)
     if center_titles:
         center_table_figure_paragraphs(result_path)
     remove_hidden_runs(result_path)
@@ -463,6 +465,7 @@ def execute_flow(task_id, flow_name):
     os.makedirs(job_dir, exist_ok=True)
     run_workflow(runtime_steps, workdir=job_dir)
     result_path = os.path.join(job_dir, "result.docx")
+    renumber_figures_tables_file(result_path)
     if center_titles:
         center_table_figure_paragraphs(result_path)
     remove_hidden_runs(result_path)

--- a/modules/Edit_Word.py
+++ b/modules/Edit_Word.py
@@ -1,5 +1,6 @@
 from spire.doc import *
 from spire.doc.common import *
+import re
 
 # ------------------------------------------------------------
 # Helpers: text insertion + numbered headings (Arabic & Roman)
@@ -145,3 +146,157 @@ def insert_bulleted_heading(section: Section, text: str, level: int = 0,
     p.ListFormat.ContinueListNumbering()
     p.Format.HorizontalAlignment = HorizontalAlignment.Left
     return p
+
+
+def renumber_figures_tables(
+    doc: Document,
+    *,
+    numbering_scope: str = "global",
+    figure_start: int = 1,
+    table_start: int = 1,
+) -> None:
+    """Renumber figures and tables and update cross-references.
+
+    Parameters
+    ----------
+    doc : Document
+        The Spire.Doc document to operate on.
+    numbering_scope : str, optional
+        "global" for one continuous sequence across the document or
+        "per-section" to reset numbering for each top-level section.
+    figure_start : int, optional
+        Starting index for figure numbering, by default 1.
+    table_start : int, optional
+        Starting index for table numbering, by default 1.
+    """
+
+    prefix_pattern = r"(Figure|Fig\.?|圖|图|Table|Tab\.?|表)"
+    number_pattern = r"\d+(?:-\d+)*"
+    # Allow common English and Chinese prefixes and digits with optional hyphen (e.g. 1-1)
+    caption_regex = re.compile(
+        rf"^{prefix_pattern}([\s\u00A0]*)({number_pattern})",
+        re.IGNORECASE,
+    )
+    # Only guard against preceding ASCII letters so Chinese text can still match
+    ref_regex = re.compile(
+        rf"(?<![A-Za-z]){prefix_pattern}([\s\u00A0]*)({number_pattern})",
+        re.IGNORECASE,
+    )
+
+    figure_map = {}
+    table_map = {}
+
+    # -------- Pass 1: build mapping of old numbers -> new numbers --------
+    fig_counter = figure_start
+    tab_counter = table_start
+    for sec_idx in range(doc.Sections.Count):
+        section = doc.Sections.get_Item(sec_idx)
+        if numbering_scope.lower() == "per-section" and sec_idx > 0:
+            fig_counter = figure_start
+            tab_counter = table_start
+
+        for p_idx in range(section.Paragraphs.Count):
+            para = section.Paragraphs.get_Item(p_idx)
+            para_text = "".join(
+                para.ChildObjects.get_Item(i).Text
+                for i in range(para.ChildObjects.Count)
+                if isinstance(para.ChildObjects.get_Item(i), TextRange)
+            )
+            text_stripped = para_text.strip()
+            m = caption_regex.match(text_stripped)
+            if not m:
+                continue
+            style_name = (para.StyleName or "").lower().replace(" ", "")
+            if (
+                "tableoffigures" in style_name
+                or "tableoftables" in style_name
+                or "tableofcontents" in style_name
+            ):
+                # Skip list/table-of entries and generated tables of contents
+                continue
+            prefix, sep, old_num = m.group(1), m.group(2), m.group(3)
+            if prefix.lower().startswith("f"):
+                new_num = (
+                    f"{sec_idx + 1}-{fig_counter}" if numbering_scope.lower() == "per-section" else str(fig_counter)
+                )
+                figure_map[old_num] = new_num
+                fig_counter += 1
+            else:
+                new_num = (
+                    f"{sec_idx + 1}-{tab_counter}" if numbering_scope.lower() == "per-section" else str(tab_counter)
+                )
+                table_map[old_num] = new_num
+                tab_counter += 1
+
+    # -------- Pass 2: replace captions and in-text references --------
+    def repl(match: re.Match) -> str:
+        prefix, sep, old = match.group(1), match.group(2), match.group(3)
+        lower = prefix.lower()
+        if lower.startswith("f"):
+            new = figure_map.get(old)
+            if new:
+                return f"{prefix}{sep}{new}"
+        else:
+            new = table_map.get(old)
+            if new:
+                return f"{prefix}{sep}{new}"
+        return match.group(0)
+
+    for sec_idx in range(doc.Sections.Count):
+        section = doc.Sections.get_Item(sec_idx)
+        for p_idx in range(section.Paragraphs.Count):
+            para = section.Paragraphs.get_Item(p_idx)
+            for r_idx in range(para.ChildObjects.Count):
+                child = para.ChildObjects.get_Item(r_idx)
+                if isinstance(child, TextRange):
+                    new_text = ref_regex.sub(repl, child.Text)
+                    if new_text != child.Text:
+                        child.Text = new_text
+
+    # Update any generated tables/lists if available
+    try:
+        doc.UpdateTableOfContents()
+    except Exception:
+        pass
+    try:
+        doc.UpdateTableOfFigures()
+    except Exception:
+        pass
+    try:
+        doc.UpdateTableOfTables()
+    except Exception:
+        pass
+
+
+def renumber_figures_tables_file(
+    docx_path: str,
+    *,
+    numbering_scope: str = "global",
+    figure_start: int = 1,
+    table_start: int = 1,
+) -> None:
+    """Load a DOCX file, renumber figures/tables, and save it back.
+
+    Parameters
+    ----------
+    docx_path : str
+        Path to the DOCX file to update in place.
+    numbering_scope : str, optional
+        "global" for one continuous sequence across the document or
+        "per-section" to reset numbering for each top-level section.
+    figure_start : int, optional
+        Starting index for figure numbering, by default 1.
+    table_start : int, optional
+        Starting index for table numbering, by default 1.
+    """
+
+    doc = Document()
+    doc.LoadFromFile(docx_path)
+    renumber_figures_tables(
+        doc,
+        numbering_scope=numbering_scope,
+        figure_start=figure_start,
+        table_start=table_start,
+    )
+    doc.SaveToFile(docx_path, FileFormat.Docx)
+    doc.Close()

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -4,7 +4,12 @@ from typing import List, Dict, Any
 from spire.doc import *
 from spire.doc.common import *
 
-from .Edit_Word import insert_text, insert_numbered_heading, insert_roman_heading, insert_bulleted_heading
+from .Edit_Word import (
+    insert_text,
+    insert_numbered_heading,
+    insert_roman_heading,
+    insert_bulleted_heading,
+)
 from .Extract_AllFile_to_FinalWord import (
     extract_pdf_chapter_to_table,
     extract_word_all_content,

--- a/tests/test_renumber_figures_tables.py
+++ b/tests/test_renumber_figures_tables.py
@@ -1,0 +1,55 @@
+from spire.doc import Document, BuiltinStyle
+from modules.Edit_Word import renumber_figures_tables
+
+
+def _paragraph_text(p):
+    # Helper to extract visible text from a paragraph
+    return p.Text.strip()
+
+
+def test_renumber_ignores_list_entries():
+    doc = Document()
+    sec = doc.AddSection()
+
+    # Simulate list-of-figures and list-of-tables entries that appear before captions
+    p0 = sec.AddParagraph()
+    p0.AppendText('Figure 3 Foo')
+    p0.ApplyStyle(BuiltinStyle.TableOfFigures)
+
+    p1 = sec.AddParagraph()
+    p1.AppendText('Table 2 Bar')
+    p1.ApplyStyle(BuiltinStyle.TableOfFigures)
+
+    # Actual captions with the same old numbers
+    p2 = sec.AddParagraph()
+    p2.AppendText('Figure 3 Foo')
+    p2.ApplyStyle(BuiltinStyle.Caption)
+
+    p3 = sec.AddParagraph()
+    p3.AppendText('Table 2 Bar')
+    p3.ApplyStyle(BuiltinStyle.Caption)
+
+    renumber_figures_tables(doc)
+
+    assert _paragraph_text(p2).startswith('Figure 1')
+    assert _paragraph_text(p3).startswith('Table 1')
+    # List entries should also reflect renumbered values
+    assert _paragraph_text(p0).startswith('Figure 1')
+    assert _paragraph_text(p1).startswith('Table 1')
+
+
+def test_reference_updated_before_caption():
+    doc = Document()
+    sec = doc.AddSection()
+
+    # In-text reference appears before the actual caption
+    ref = sec.AddParagraph()
+    ref.AppendText('The appearance is shown in Figure 3.')
+
+    cap = sec.AddParagraph()
+    cap.AppendText('Figure 3 Sample figure caption')
+
+    renumber_figures_tables(doc)
+
+    assert 'Figure 1' in _paragraph_text(ref)
+    assert _paragraph_text(cap).startswith('Figure 1')


### PR DESCRIPTION
## Summary
- remove caption-style requirement and detect figure/table captions by leading labels
- skip list-of-figures/table entries when building renumber map
- cover in-text references that appear before captions with a new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d48e35e48323aaa981dba93532d6