### PR TITLE
Enable building workflows from mapping spreadsheets

### DIFF
--- a/modules/mapping_parser.py
+++ b/modules/mapping_parser.py
@@ -1,0 +1,160 @@
+"""Utilities for parsing mapping Excel files into workflow steps.
+
+This module reads an Excel mapping file with four columns:
+A: output Word document name
+B: heading title inside the Word document
+C: input file name to search within task files
+D: extraction instruction. When it contains a chapter number (e.g. "6.12.1"),
+   the specified chapter is extracted via ``extract_word_chapter``. When the
+   value is ``all`` (case-insensitive) the entire document is extracted via
+   ``extract_word_all_content``. Otherwise the value is treated as keywords for
+   file copying.
+
+The parsing result consists of two collections:
+- A dictionary mapping each output document name to a list of workflow steps
+  (heading insertion and content extraction steps) that can later be executed
+  by ``run_workflow``.
+- A list of copy jobs describing keyword based file copying tasks.
+"""
+from __future__ import annotations
+
+import os
+import re
+import zipfile
+import xml.etree.ElementTree as ET
+from typing import Dict, List, Tuple, Optional
+
+# Type aliases for clarity
+Workflow = Dict[str, List[Dict[str, dict]]]
+CopyJob = Dict[str, object]
+
+def _find_file(base_dir: str, name: str) -> Optional[str]:
+    """Search for a file whose basename matches ``name`` (case-insensitive)."""
+    if not name:
+        return None
+    lowered = name.lower()
+    for root, _dirs, files in os.walk(base_dir):
+        for fn in files:
+            if fn.lower() == lowered:
+                return os.path.join(root, fn)
+    return None
+
+
+def _column_index(col_ref: str) -> int:
+    idx = 0
+    for ch in col_ref:
+        if 'A' <= ch <= 'Z':
+            idx = idx * 26 + (ord(ch) - 64)
+    return idx - 1
+
+
+def _read_rows(xlsx_path: str) -> List[List[str]]:
+    """Very small helper to read rows from the first worksheet of an XLSX file."""
+    rows: List[List[str]] = []
+    with zipfile.ZipFile(xlsx_path) as zf:
+        shared_strings: List[str] = []
+        if "xl/sharedStrings.xml" in zf.namelist():
+            root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+            ns = {"t": root.tag.split('}')[0].strip('{')}
+            for si in root.findall(".//t:si", ns):
+                text_parts = [t.text or "" for t in si.findall(".//t:t", ns)]
+                shared_strings.append("".join(text_parts))
+        sheet = ET.fromstring(zf.read("xl/worksheets/sheet1.xml"))
+        ns_sheet = {"t": sheet.tag.split('}')[0].strip('{')}
+        for row in sheet.findall(".//t:row", ns_sheet):
+            cells: List[str] = []
+            for c in row.findall("t:c", ns_sheet):
+                r = c.get("r", "A1")
+                col_letters = re.match(r"([A-Z]+)", r).group(1)
+                idx = _column_index(col_letters)
+                while len(cells) <= idx:
+                    cells.append("")
+                t = c.get("t")
+                v = c.find("t:v", ns_sheet)
+                val = v.text if v is not None else ""
+                if t == "s" and val.isdigit():
+                    sidx = int(val)
+                    val = shared_strings[sidx] if sidx < len(shared_strings) else ""
+                cells[idx] = val
+            rows.append(cells)
+    return rows
+
+def parse_mapping_file(xlsx_path: str, task_files_dir: str) -> Tuple[Workflow, List[CopyJob]]:
+    """Parse mapping instructions from an Excel file.
+
+    Parameters
+    ----------
+    xlsx_path: str
+        Path to the mapping Excel file.
+    task_files_dir: str
+        Base directory containing uploaded task files.
+
+    Returns
+    -------
+    Tuple[Workflow, List[CopyJob]]
+        ``Workflow`` maps output document names to lists of workflow steps.
+        ``CopyJob`` items describe keyword based file copying operations.
+    """
+    workflows: Workflow = {}
+    copy_jobs: List[CopyJob] = []
+
+    rows = _read_rows(xlsx_path)
+    for row in rows[1:]:  # skip header
+        out_doc, heading, filename, instruction = row[:4]
+        if not any([out_doc, heading, filename, instruction]):
+            continue
+        out_doc = str(out_doc).strip() if out_doc else ""  # group by document
+        heading = str(heading).strip() if heading else ""
+        filename = str(filename).strip() if filename else ""
+        instruction = str(instruction).strip() if instruction else ""
+
+        # Determine file path if a filename is provided
+        file_path = _find_file(task_files_dir, filename) if filename else None
+
+        # Normalise workflow list for this document
+        if out_doc:
+            steps = workflows.setdefault(out_doc, [])
+        else:
+            steps = workflows.setdefault("result", [])
+
+        if instruction.lower() == "all" and file_path:
+            # Extract entire document
+            steps.append({
+                "type": "insert_numbered_heading",
+                "params": {"text": heading, "level": 1},
+            })
+            rel = os.path.relpath(file_path, task_files_dir)
+            steps.append({
+                "type": "extract_word_all_content",
+                "params": {"input_file": rel},
+            })
+            continue
+
+        m = re.match(r"([\d\.]+)\s*(.*)", instruction)
+        if m and file_path:
+            # Extract specific chapter (and optional title)
+            chapter = m.group(1)
+            title_section = m.group(2).strip()
+            steps.append({
+                "type": "insert_numbered_heading",
+                "params": {"text": heading, "level": 1},
+            })
+            params = {
+                "input_file": os.path.relpath(file_path, task_files_dir),
+                "target_chapter_section": chapter,
+                "target_title": bool(title_section),
+                "target_title_section": title_section,
+            }
+            steps.append({"type": "extract_word_chapter", "params": params})
+            continue
+
+        # Otherwise treat as keywords for file copy
+        keywords = [k.strip() for k in instruction.split(",") if k.strip()]
+        dest_dir = os.path.join(task_files_dir, out_doc, heading)
+        copy_jobs.append({
+            "source": task_files_dir,
+            "dest": dest_dir,
+            "keywords": keywords or ([filename] if filename else []),
+        })
+
+    return workflows, copy_jobs

--- a/tests/test_mapping_parser.py
+++ b/tests/test_mapping_parser.py
@@ -1,0 +1,151 @@
+import os
+import os
+import os
+import zipfile
+import xml.etree.ElementTree as ET
+
+from modules.mapping_parser import parse_mapping_file
+
+
+def create_mapping(path):
+    strings = [
+        "doc",
+        "title",
+        "file",
+        "instruction",
+        "Doc1",
+        "Heading1",
+        "a.docx",
+        "1.2 Intro",
+        "Heading2",
+        "b.docx",
+        "all",
+        "Doc2",
+        "CopySec",
+        "keyword",
+    ]
+
+    # sharedStrings.xml
+    ss = ET.Element(
+        "sst",
+        xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+        count=str(len(strings)),
+        uniqueCount=str(len(strings)),
+    )
+    for s in strings:
+        si = ET.SubElement(ss, "si")
+        t = ET.SubElement(si, "t")
+        t.text = s
+    shared_strings = ET.tostring(ss, encoding="utf-8", xml_declaration=True)
+
+    # sheet1.xml with shared string references
+    ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    sheet = ET.Element("worksheet", xmlns=ns)
+    sheetData = ET.SubElement(sheet, "sheetData")
+
+    def add_row(r_idx, indices):
+        row = ET.SubElement(sheetData, "row", r=str(r_idx))
+        for c_idx, idx in enumerate(indices):
+            if idx is None:
+                continue
+            col = chr(65 + c_idx)
+            c = ET.SubElement(row, "c", r=f"{col}{r_idx}", t="s")
+            v = ET.SubElement(c, "v")
+            v.text = str(idx)
+
+    add_row(1, [0, 1, 2, 3])
+    add_row(2, [4, 5, 6, 7])
+    add_row(3, [4, 8, 9, 10])
+    add_row(4, [11, 12, None, 13])
+    sheet_xml = ET.tostring(sheet, encoding="utf-8", xml_declaration=True)
+
+    content_types = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">
+  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>
+  <Default Extension=\"xml\" ContentType=\"application/xml\"/>
+  <Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>
+  <Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>
+  <Override PartName=\"/xl/sharedStrings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\"/>
+  <Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>
+  <Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>
+  <Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>
+</Types>"""
+
+    rels_rels = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>
+  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>
+  <Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>
+</Relationships>"""
+
+    workbook = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">
+  <sheets>
+    <sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/>
+  </sheets>
+</workbook>"""
+
+    workbook_rels = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>
+  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>
+  <Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>
+</Relationships>"""
+
+    styles = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">
+  <fonts count=\"1\"><font><sz val=\"11\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/></font></fonts>
+  <fills count=\"1\"><fill><patternFill patternType=\"none\"/></fill></fills>
+  <borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
+  <cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>
+  <cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>
+</styleSheet>"""
+
+    core = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">
+  <dc:creator>test</dc:creator>
+  <cp:lastModifiedBy>test</cp:lastModifiedBy>
+  <dcterms:created xsi:type=\"dcterms:W3CDTF\">2024-01-01T00:00:00Z</dcterms:created>
+  <dcterms:modified xsi:type=\"dcterms:W3CDTF\">2024-01-01T00:00:00Z</dcterms:modified>
+</cp:coreProperties>"""
+
+    app = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/extended-properties\" xmlns:vt=\"http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes\">
+  <Application>Python</Application>
+</Properties>"""
+
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("[Content_Types].xml", content_types)
+        zf.writestr("_rels/.rels", rels_rels)
+        zf.writestr("xl/workbook.xml", workbook)
+        zf.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
+        zf.writestr("xl/styles.xml", styles)
+        zf.writestr("xl/sharedStrings.xml", shared_strings)
+        zf.writestr("xl/worksheets/sheet1.xml", sheet_xml)
+        zf.writestr("docProps/core.xml", core)
+        zf.writestr("docProps/app.xml", app)
+
+
+def test_parse_mapping_file(tmp_path):
+    mapping_path = tmp_path / "map.xlsx"
+    create_mapping(mapping_path)
+
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    (files_dir / "a.docx").write_text("")
+    (files_dir / "b.docx").write_text("")
+
+    flows, copies = parse_mapping_file(str(mapping_path), str(files_dir))
+
+    assert "Doc1" in flows
+    steps = flows["Doc1"]
+    assert len(steps) == 4
+    assert steps[0]["type"] == "insert_numbered_heading"
+    assert steps[1]["type"] == "extract_word_chapter"
+    assert steps[1]["params"]["target_chapter_section"] == "1.2"
+    assert steps[3]["type"] == "extract_word_all_content"
+
+    assert copies
+    job = copies[0]
+    assert job["dest"].endswith(os.path.join("Doc2", "CopySec"))
+    assert job["keywords"] == ["keyword"]


### PR DESCRIPTION
## Summary
- allow uploading a mapping `.xlsx` file to build and execute document workflows
- parse mapping spreadsheets to convert rows into workflow steps and file copy jobs
- add tests for the mapping parser

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be322c4a348323a5c125351baba5a1