### PR TITLE
feat: add mapping workflow builder

### DIFF
--- a/modules/file_copier.py
+++ b/modules/file_copier.py
@@ -17,7 +17,9 @@ def copy_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
     destination: str
         Directory where matched files will be copied.
     keywords: Iterable[str]
-        Keywords that must all be present in the filename.
+        Keywords that must all be present in the filename. For example,
+        passing ["Shipping simulation test", "EO"] will match only files whose
+        names contain both phrases.
 
     Returns
     -------
@@ -30,13 +32,24 @@ def copy_files(source: str, destination: str, keywords: Iterable[str]) -> List[s
     os.makedirs(destination, exist_ok=True)
     copied_files: List[str] = []
     lowered_keywords = [k.strip().lower() for k in keywords if k.strip()]
+    dest_abs = os.path.abspath(destination)
 
-    for root, _dirs, files in os.walk(source):
+    for root, dirs, files in os.walk(source):
+        # Avoid walking into the destination directory to prevent copying files
+        # onto themselves when the destination lives inside the source.
+        dirs[:] = [
+            d for d in dirs if os.path.abspath(os.path.join(root, d)) != dest_abs
+        ]
+
         for name in files:
             lower_name = name.lower()
             if all(k in lower_name for k in lowered_keywords):
                 src_path = os.path.join(root, name)
                 dest_path = os.path.join(destination, name)
+                # Skip copying when the source and destination resolve to the
+                # same file (e.g., destination inside source and already visited)
+                if os.path.abspath(src_path) == os.path.abspath(dest_path):
+                    continue
                 shutil.copy2(src_path, dest_path)
                 copied_files.append(dest_path)
     return copied_files

--- a/modules/mapping_processor.py
+++ b/modules/mapping_processor.py
@@ -1,0 +1,159 @@
+import os
+import re
+from typing import Dict, List, Tuple
+
+from spire.doc import Document, FileFormat
+
+from .Edit_Word import (
+    insert_numbered_heading,
+    insert_roman_heading,
+    insert_bulleted_heading,
+)
+from .Extract_AllFile_to_FinalWord import (
+    extract_word_all_content,
+    extract_word_chapter,
+)
+from .file_copier import copy_files
+
+
+def _find_file(base: str, filename: str) -> str | None:
+    """Search *base* recursively for *filename* ignoring case."""
+    target = filename.lower()
+    for root, _dirs, files in os.walk(base):
+        for fn in files:
+            if fn.lower() == target:
+                return os.path.join(root, fn)
+    return None
+
+
+def insert_title(section, title: str):
+    """Insert *title* into *section* with appropriate heading style.
+
+    - Titles beginning with Roman numerals (e.g. ``"I."``, ``"II."``) use
+      :func:`insert_roman_heading`.
+    - Titles beginning with a ``"⚫"`` bullet use :func:`insert_bulleted_heading`.
+    - All other titles use :func:`insert_numbered_heading`.
+    """
+
+    if not title:
+        return None
+
+    roman_match = re.match(r"^[IVXLCDM]+\.\s*(.*)", title)
+    if roman_match:
+        text = roman_match.group(1).strip() or title
+        return insert_roman_heading(section, text, level=0, bold=True, font_size=14)
+
+    if title.startswith("⚫"):
+        text = title.lstrip("⚫").strip()
+        return insert_bulleted_heading(section, text, level=0, bold=True, font_size=14)
+
+    return insert_numbered_heading(section, title, level=0, bold=True, font_size=14)
+
+
+def process_mapping_excel(mapping_path: str, task_files_dir: str, output_dir: str) -> Dict[str, List[str]]:
+    """Process mapping Excel file and generate documents or copy files.
+
+    Returns a dict with keys:
+        logs: list of messages
+        outputs: list of generated docx paths
+    """
+    logs: List[str] = []
+    docs: Dict[str, Tuple[Document, any]] = {}
+    outputs: List[str] = []
+
+    try:
+        from openpyxl import load_workbook
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError("openpyxl is required to process mapping files") from e
+
+    wb = load_workbook(mapping_path)
+    ws = wb.active
+
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        raw_out, raw_title, raw_input, raw_instruction = row[:4]
+        out_name = str(raw_out).strip() if raw_out else ""
+        title = str(raw_title).strip() if raw_title else ""
+        input_name = str(raw_input).strip() if raw_input else ""
+        instruction = str(raw_instruction).strip() if raw_instruction else ""
+        if not instruction:
+            continue
+
+        # Step 2: 確認欄位D需擷取內容
+        is_all = instruction.lower() == "all"
+        chapter_match = re.match(r"^([0-9]+(?:\.[0-9]+)*)(?:.*)", instruction)
+
+        if is_all or chapter_match:
+            # Step 1: 確認欄位C輸入檔案名稱
+            if not input_name:
+                logs.append(f"{out_name or '未命名'}: 未提供輸入檔案名稱")
+                continue
+            infile = _find_file(task_files_dir, input_name)
+            if not infile:
+                logs.append(f"{out_name or '未命名'}: 找不到檔案 {input_name}")
+                continue
+
+            # Step 3: 確認欄位A輸出檔案名稱
+            doc, section = docs.get(out_name, (None, None))
+            if doc is None:
+                doc = Document()
+                section = doc.AddSection()
+                docs[out_name] = (doc, section)
+
+            # Step 4: 確認欄位B需寫入文件的標題
+            insert_title(section, title)
+
+            # Step 5: 建構文件流程
+            if is_all:
+                extract_word_all_content(infile, output_doc=doc, section=section)
+                logs.append(f"擷取 {input_name} 全部內容")
+            else:
+                chapter = chapter_match.group(1)
+                if "," in instruction:
+                    _prefix, after = instruction.split(",", 1)
+                    extract_word_chapter(
+                        infile,
+                        chapter,
+                        target_title=True,
+                        target_title_section=after.strip(),
+                        output_doc=doc,
+                        section=section,
+                    )
+                    logs.append(f"擷取 {input_name} 章節 {chapter} 標題 {after.strip()}")
+                else:
+                    extract_word_chapter(
+                        infile,
+                        chapter,
+                        output_doc=doc,
+                        section=section,
+                    )
+                    logs.append(f"擷取 {input_name} 章節 {chapter}")
+        else:
+            # copy files by keywords
+            dest = os.path.join(task_files_dir, out_name or "output")
+            if title:
+                dest = os.path.join(dest, title)
+            # Allow multiple keywords separated by commas (e.g. "Shipping simulation test, EO")
+            # and ensure that matched files contain *all* keywords.
+            keywords = [
+                k.strip()
+                for k in re.split(r"[,，]+", instruction)
+                if k.strip()
+            ]
+            try:
+                copied = copy_files(task_files_dir, dest, keywords)
+                kw_display = ", ".join(keywords)
+                logs.append(
+                    f"複製 {len(copied)} 個檔案至 {os.path.relpath(dest, task_files_dir)} (關鍵字: {kw_display})"
+                )
+            except Exception as e:
+                logs.append(f"複製檔案失敗: {e}")
+
+    os.makedirs(output_dir, exist_ok=True)
+    for name, (doc, _section) in docs.items():
+        out_path = os.path.join(output_dir, f"{name}.docx")
+        doc.SaveToFile(out_path, FileFormat.Docx)
+        doc.Close()
+        outputs.append(out_path)
+        logs.append(f"產生文件 {out_path}")
+
+    return {"logs": logs, "outputs": outputs}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-docx==1.1.2
 PyMuPDF==1.24.8
 spire.doc==12.1.0
 boto3
+openpyxl==3.1.2

--- a/templates/mapping.html
+++ b/templates/mapping.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h4 mb-3">上傳 Mapping 檔案</h1>
+<form method="post" enctype="multipart/form-data" class="card card-body mb-4">
+  <div class="row g-3">
+    <div class="col-md-9">
+      <input class="form-control" type="file" name="mapping_file" required>
+    </div>
+    <div class="col-md-3 d-grid">
+      <button class="btn btn-primary" type="submit">開始處理</button>
+    </div>
+  </div>
+</form>
+{% if messages %}
+<h2 class="h6">處理狀態</h2>
+<ul class="list-group mb-3">
+  {% for m in messages %}
+  <li class="list-group-item">{{ m }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if outputs %}
+<h2 class="h6">產出文件</h2>
+<ul class="list-group mb-3">
+  {% for name in outputs %}
+  <li class="list-group-item"><a href="{{ url_for('task_download_output', task_id=task_id, filename=name) }}">{{ name }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+<a class="btn btn-secondary" href="{{ url_for('task_detail', task_id=task_id) }}">返回任務</a>
+{% endblock %}

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -40,6 +40,7 @@
 <div class="d-flex gap-2">
   <a class="btn btn-primary" href="{{ url_for('flow_builder', task_id=task.id) }}">管理流程</a>
   <a class="btn btn-outline-primary" href="{{ url_for('task_copy_files', task_id=task.id) }}">複製檔案</a>
+  <a class="btn btn-outline-primary" href="{{ url_for('task_mapping', task_id=task.id) }}">上傳 Mapping</a>
   <a class="btn btn-outline-secondary" href="{{ url_for('tasks') }}">回首頁</a>
 </div>
 {% endblock %}

--- a/tests/test_file_copier.py
+++ b/tests/test_file_copier.py
@@ -20,3 +20,43 @@ def test_copy_files_overwrite(tmp_path):
     file_path.write_text("second")
     copy_files(str(src), str(dest), ["example"])
     assert dest_file.read_text() == "second"
+
+
+def test_copy_files_multiple_keywords(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.mkdir()
+    dest.mkdir()
+
+    # File that matches both keywords
+    (src / "Shipping simulation test EO report.txt").write_text("data")
+    # File that matches only one keyword and should not be copied
+    (src / "Shipping simulation test only.txt").write_text("data")
+
+    copied = copy_files(
+        str(src),
+        str(dest),
+        ["Shipping simulation test", "EO"],
+    )
+
+    assert dest.joinpath("Shipping simulation test EO report.txt").exists()
+    assert not dest.joinpath("Shipping simulation test only.txt").exists()
+    assert len(copied) == 1
+
+
+def test_copy_files_destination_inside_source(tmp_path):
+    src = tmp_path / "root"
+    dest = src / "dest"
+    src.mkdir()
+    dest.mkdir()
+
+    (src / "report.txt").write_text("data")
+
+    copied = copy_files(str(src), str(dest), ["report"])
+
+    dest_file = dest / "report.txt"
+    assert dest_file.exists()
+    assert dest_file.read_text() == "data"
+    assert copied == [str(dest_file)]
+    # Ensure only the copied file exists in destination
+    assert len(list(dest.iterdir())) == 1

--- a/tests/test_insert_title.py
+++ b/tests/test_insert_title.py
@@ -1,0 +1,27 @@
+from spire.doc import Document
+from modules.mapping_processor import insert_title
+
+
+def _style_name(p):
+    return p.ListFormat.CustomStyleName
+
+
+def test_insert_title_numbered():
+    doc = Document()
+    sec = doc.AddSection()
+    p = insert_title(sec, "Heading")
+    assert _style_name(p) == "outlineHeading"
+
+
+def test_insert_title_roman():
+    doc = Document()
+    sec = doc.AddSection()
+    p = insert_title(sec, "I. Scope")
+    assert _style_name(p) == "romanHeading"
+
+
+def test_insert_title_bullet():
+    doc = Document()
+    sec = doc.AddSection()
+    p = insert_title(sec, "⚫ Item")
+    assert _style_name(p) == "bulletHeading"


### PR DESCRIPTION
## Summary
- allow uploading mapping Excel to build document workflow
- process mapping to extract content or copy files
- expose mapping upload page with output downloads
- support comma-separated keywords (e.g., "Shipping simulation test, EO") that must all appear in filenames
- prevent self-copies when the destination folder resides inside the source
- insert Roman numeral or bullet headings based on mapping titles

## Testing
- `pip install openpyxl` (fails: Could not find a version that satisfies the requirement openpyxl)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be55d0ccb08323ac4c80b6dd9fe4e9