### PR TITLE
feat: add version history for compare results

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import uuid
 import json
 import zipfile
 import re
+import shutil
 from datetime import datetime
 from flask import (
     Flask,
@@ -13,6 +14,7 @@ from flask import (
     send_file,
     send_from_directory,
     abort,
+    jsonify,
 )
 from werkzeug.utils import secure_filename
 from modules.workflow import SUPPORTED_STEPS, run_workflow
@@ -36,6 +38,8 @@ os.makedirs(app.config["TASK_FOLDER"], exist_ok=True)
 ALLOWED_DOCX = {".docx"}
 ALLOWED_PDF = {".pdf"}
 ALLOWED_ZIP = {".zip"}
+
+MAX_VERSIONS = 20
 
 
 def allowed_file(filename, kinds=("docx", "pdf", "zip")):
@@ -95,6 +99,39 @@ def task_name_exists(name, exclude_id=None):
         if tname == name:
             return True
     return False
+
+
+def save_version(job_dir: str, note: str = "") -> None:
+    """Backup current result files into versions directory with metadata."""
+    versions_dir = os.path.join(job_dir, "versions")
+    os.makedirs(versions_dir, exist_ok=True)
+    meta_path = os.path.join(versions_dir, "metadata.json")
+    metadata = []
+    if os.path.exists(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+    version = metadata[-1]["version"] + 1 if metadata else 1
+    html_src = os.path.join(job_dir, "result.html")
+    docx_src = os.path.join(job_dir, "result.docx")
+    if os.path.exists(html_src):
+        shutil.copy2(html_src, os.path.join(versions_dir, f"result_{version}.html"))
+    if os.path.exists(docx_src):
+        shutil.copy2(docx_src, os.path.join(versions_dir, f"result_{version}.docx"))
+    metadata.append(
+        {
+            "version": version,
+            "saved_at": datetime.now().isoformat(timespec="seconds"),
+            "note": note,
+        }
+    )
+    while len(metadata) > MAX_VERSIONS:
+        old = metadata.pop(0)
+        for ext in ("html", "docx"):
+            old_path = os.path.join(versions_dir, f"result_{old['version']}.{ext}")
+            if os.path.exists(old_path):
+                os.remove(old_path)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, ensure_ascii=False, indent=2)
 
 @app.route("/tasks/<task_id>/copy-files", methods=["GET", "POST"], endpoint="task_copy_files")
 def task_copy_files(task_id):
@@ -715,6 +752,14 @@ def task_compare(task_id, job_id):
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
         save_url=url_for("task_compare_save", task_id=task_id, job_id=job_id),
         download_url=url_for("task_download", task_id=task_id, job_id=job_id, kind="docx"),
+        versions_url=url_for("task_compare_versions", task_id=task_id, job_id=job_id),
+        revert_url_base=url_for("task_compare_revert", task_id=task_id, job_id=job_id, version=0),
+        version_download_base=url_for(
+            "task_view_file",
+            task_id=task_id,
+            job_id=job_id,
+            filename="versions/result_0.docx",
+        ),
     )
 
 
@@ -722,10 +767,9 @@ def task_compare(task_id, job_id):
 def task_compare_save(task_id, job_id):
     tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
     job_dir = os.path.join(tdir, "jobs", job_id)
-    html_content = request.form.get("html")
-    if not html_content:
-        data = request.get_json(silent=True) or {}
-        html_content = data.get("html", "")
+    data = request.get_json(silent=True) or {}
+    html_content = request.form.get("html") or data.get("html", "")
+    note = request.form.get("note") or data.get("note", "")
     if not html_content:
         return "缺少內容", 400
     # Remove any hidden elements marked via CSS display:none to strip chapter titles
@@ -754,6 +798,34 @@ def task_compare_save(task_id, job_id):
     result_docx = os.path.join(job_dir, "result.docx")
     remove_hidden_runs(result_docx)
     apply_basic_style(result_docx)
+    save_version(job_dir, note or "")
+    return "OK"
+
+
+@app.get("/tasks/<task_id>/compare/<job_id>/versions")
+def task_compare_versions(task_id, job_id):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    versions_dir = os.path.join(tdir, "jobs", job_id, "versions")
+    meta_path = os.path.join(versions_dir, "metadata.json")
+    if not os.path.exists(meta_path):
+        return jsonify([])
+    with open(meta_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return jsonify(data)
+
+
+@app.post("/tasks/<task_id>/compare/<job_id>/revert/<int:version>")
+def task_compare_revert(task_id, job_id, version):
+    tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
+    job_dir = os.path.join(tdir, "jobs", job_id)
+    versions_dir = os.path.join(job_dir, "versions")
+    html_src = os.path.join(versions_dir, f"result_{version}.html")
+    docx_src = os.path.join(versions_dir, f"result_{version}.docx")
+    if not os.path.exists(html_src) or not os.path.exists(docx_src):
+        abort(404)
+    save_version(job_dir, f"revert to {version}")
+    shutil.copy2(html_src, os.path.join(job_dir, "result.html"))
+    shutil.copy2(docx_src, os.path.join(job_dir, "result.docx"))
     return "OK"
 
 
@@ -765,7 +837,11 @@ def task_view_file(task_id, job_id, filename):
     file_path = os.path.join(job_dir, safe_filename)
     if not os.path.isfile(file_path):
         abort(404)
-    return send_from_directory(job_dir, safe_filename)
+    resp = send_from_directory(job_dir, safe_filename)
+    resp.headers["Cache-Control"] = "no-store"
+    resp.headers["Pragma"] = "no-cache"
+    resp.headers["Expires"] = "0"
+    return resp
 
 
 @app.get("/tasks/<task_id>/download/<job_id>/<kind>")
@@ -773,17 +849,25 @@ def task_download(task_id, job_id, kind):
     tdir = os.path.join(app.config["TASK_FOLDER"], task_id)
     job_dir = os.path.join(tdir, "jobs", job_id)
     if kind == "docx":
-        return send_file(
+        resp = send_file(
             os.path.join(job_dir, "result.docx"),
             as_attachment=True,
             download_name=f"result_{job_id}.docx",
         )
+        resp.headers["Cache-Control"] = "no-store"
+        resp.headers["Pragma"] = "no-cache"
+        resp.headers["Expires"] = "0"
+        return resp
     elif kind == "log":
-        return send_file(
+        resp = send_file(
             os.path.join(job_dir, "log.json"),
             as_attachment=True,
             download_name=f"log_{job_id}.json",
         )
+        resp.headers["Cache-Control"] = "no-store"
+        resp.headers["Pragma"] = "no-cache"
+        resp.headers["Expires"] = "0"
+        return resp
     abort(404)
 
 

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -11,6 +11,7 @@
       <div class="d-flex gap-2">
         <button id="modeBtn" class="btn btn-outline-secondary" type="button">編輯模式</button>
         <button id="saveBtn" class="btn btn-primary" type="button">保存</button>
+        <button id="versionsBtn" class="btn btn-outline-secondary" type="button">版本歷程</button>
         <button id="downloadBtn" class="btn btn-success" type="button">下載</button>
         <a class="btn btn-secondary" href="{{ back_link }}">返回結果</a>
       </div>
@@ -30,12 +31,30 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="versionsModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">版本歷程</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul id="versionList" class="list-group"></ul>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
 const SOURCE_URLS = {{ source_urls|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
 const CHAPTER_SET = new Set(CHAPTERS);
+const VERSIONS_URL = '{{ versions_url }}';
+const REVERT_URL_BASE = '{{ revert_url_base }}';
+const VERSION_DOWNLOAD_BASE = '{{ version_download_base }}';
+const HTML_URL = '{{ html_url }}';
 let highlighted = [];
 
 function openWindow(url) {
@@ -201,7 +220,46 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
     alert('請先保存才可下載');
     return;
   }
-  window.location = '{{ download_url }}';
+  window.location = '{{ download_url }}?t=' + Date.now();
+});
+
+document.getElementById('versionsBtn').addEventListener('click', () => {
+  fetch(VERSIONS_URL).then(r => r.json()).then(list => {
+    const ul = document.getElementById('versionList');
+    ul.innerHTML = '';
+    list.slice().reverse().forEach(v => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item d-flex justify-content-between align-items-center';
+      const span = document.createElement('span');
+      span.textContent = `版本 ${v.version} - ${v.saved_at}${v.note ? ' - ' + v.note : ''}`;
+      const btns = document.createElement('div');
+      const dl = document.createElement('a');
+      dl.className = 'btn btn-sm btn-outline-success me-2';
+      dl.textContent = '下載';
+      dl.href = VERSION_DOWNLOAD_BASE.replace('result_0', `result_${v.version}`);
+      btns.appendChild(dl);
+      const rv = document.createElement('button');
+      rv.className = 'btn btn-sm btn-outline-primary';
+      rv.textContent = '復原';
+      rv.addEventListener('click', () => {
+        fetch(REVERT_URL_BASE.replace(/0$/, v.version), {method:'POST'}).then(rr => {
+          if (rr.ok) {
+            iframe.src = HTML_URL + '?t=' + Date.now();
+            setSaved(true);
+            bootstrap.Modal.getInstance(document.getElementById('versionsModal')).hide();
+            alert('已復原');
+          } else {
+            alert('復原失敗');
+          }
+        });
+      });
+      btns.appendChild(rv);
+      li.appendChild(span);
+      li.appendChild(btns);
+      ul.appendChild(li);
+    });
+    new bootstrap.Modal(document.getElementById('versionsModal')).show();
+  });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- backup previous compare results and store metadata
- list and revert versions via new endpoints
- add UI for version history and restore
- disable caching so downloads always reflect latest changes
- store latest save into version history so downloads contain recent edits

## Testing
- `pytest` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68bf802a75d8832394e20b59673caba5