### PR TITLE
Normalize whitespace for chapter lookup

### DIFF
--- a/templates/compare.html
+++ b/templates/compare.html
@@ -166,7 +166,8 @@ iframe.addEventListener('load', () => {
   let found = false;
   let unhandled = [];
   CHAPTERS.forEach(ch => {
-    const elements = Array.from(doc.body.querySelectorAll('*')).filter(el => el.textContent.trim() === ch);
+    const normalizedCh = ch.replace(/\s+/g, '');
+    const elements = Array.from(doc.body.querySelectorAll('*')).filter(el => el.textContent.replace(/\s+/g, '') === normalizedCh);
     if (elements.length) {
       found = true;
       elements.forEach(el => {


### PR DESCRIPTION
## Summary
- ignore extra whitespace and non-breaking spaces when matching chapter elements in compare.html

## Testing
- `pytest -q` *(fails: insert_title missing outlineHeading style, mapping processor tests failing to generate docs)*

------
https://chatgpt.com/codex/tasks/task_e_68bff345f80c8323850017df04dc0415