### PR TITLE
Prevent removal of last paragraph in table cells

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -331,6 +331,12 @@ def remove_hidden_runs(input_file: str) -> bool:
                 )
             )
             if not para.text.strip() and not has_image:
+                parent = para._element.getparent()
+                if parent is not None and parent.tag == qn('w:tc'):
+                    # Ensure each table cell keeps at least one paragraph
+                    paragraph_count = len(parent.findall(qn('w:p')))
+                    if paragraph_count <= 1:
+                        continue
                 p = para._element
                 p.getparent().remove(p)
         doc.save(input_file)

--- a/tests/test_remove_hidden_runs.py
+++ b/tests/test_remove_hidden_runs.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from docx import Document
+
+from modules.Extract_AllFile_to_FinalWord import remove_hidden_runs
+
+
+def test_remove_hidden_runs_keeps_paragraph_in_table_cell(tmp_path: Path) -> None:
+    doc = Document()
+    table = doc.add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    para = cell.paragraphs[0]
+    run = para.add_run("to hide")
+    run.font.hidden = True
+
+    doc_path = tmp_path / "table.docx"
+    doc.save(doc_path)
+
+    assert remove_hidden_runs(str(doc_path))
+
+    updated = Document(doc_path)
+    cell_after = updated.tables[0].cell(0, 0)
+
+    # Even though all visible text was removed, the table cell must keep a paragraph
+    assert len(cell_after.paragraphs) == 1
+    assert cell_after.paragraphs[0].text == ""


### PR DESCRIPTION
## Summary
- skip deleting a paragraph when it is the final paragraph inside a table cell so DOCX cells always retain a <w:p>
- add a regression test covering the hidden-run removal workflow to ensure table cells keep a paragraph

## Testing
- pytest *(fails: pre-existing failures in test_insert_title.py::test_insert_title_numbered, test_insert_title.py::test_insert_title_strips_chapter_number, tests in test_mapping_processor.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c9306821cc832391ca1fd89d9e1f18