### PR TITLE
Allow updating document format for saved flows

### DIFF
--- a/templates/flow.html
+++ b/templates/flow.html
@@ -33,6 +33,29 @@
     <label class="form-check-label" for="center_titles">置中 Table/Figure 標題段落</label>
   </div>
 
+  <div class="row g-3 align-items-end">
+    <div class="col-md-6">
+      <label class="form-label" for="document_format">文件格式</label>
+      <select class="form-select" id="document_format" name="document_format">
+        {% for key, meta in format_presets.items() %}
+        <option value="{{ key }}" {% if key == selected_format %}selected{% endif %}>{{ meta.label }}</option>
+        {% endfor %}
+      </select>
+      <div class="form-text" id="document_format_help"></div>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label" for="line_spacing">行距</label>
+      <select class="form-select" id="line_spacing" name="line_spacing">
+        {% for value, label in line_spacing_choices %}
+        <option value="{{ value }}" {% if value == selected_line_spacing %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+        {% if selected_line_spacing and selected_line_spacing not in line_spacing_values %}
+        <option value="{{ selected_line_spacing }}" selected>自訂（{{ selected_line_spacing }}）</option>
+        {% endif %}
+      </select>
+    </div>
+  </div>
+
   <div class="d-flex gap-2 mt-2">
     <div class="dropdown">
       <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">新增步驟</button>
@@ -66,20 +89,40 @@
 </div>
 <hr>
 <h2 class="h5 mt-4">已保存的流程</h2>
-<table class="table table-striped text-center">
+<table class="table table-striped text-center align-middle">
   <thead>
     <tr>
       <th class="text-center">名稱</th>
       <th class="text-center">建立時間</th>
+      <th class="text-center">文件格式 / 行距</th>
       <th class="text-center">操作</th>
     </tr>
   </thead>
   <tbody>
   {% for f in flows %}
     <tr>
-      <td>{{ f.name }}</td>
-      <td>{{ f.created }}</td>
-      <td>
+      <td class="align-middle">{{ f.name }}</td>
+      <td class="align-middle">{{ f.created }}</td>
+      <td class="align-middle">
+        <form action="{{ url_for('update_flow_format', task_id=task.id, flow_name=f.name) }}" method="post" class="d-flex flex-column flex-lg-row gap-2 align-items-stretch align-items-lg-center justify-content-center">
+          <select class="form-select form-select-sm" name="document_format">
+            {% for key, meta in format_presets.items() %}
+            <option value="{{ key }}" {% if key == f.document_format %}selected{% endif %}>{{ meta.label }}</option>
+            {% endfor %}
+          </select>
+          <select class="form-select form-select-sm" name="line_spacing">
+            {% for value, label in line_spacing_choices %}
+            <option value="{{ value }}" {% if value == f.line_spacing_value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+            {% if f.line_spacing_value and f.line_spacing_value not in line_spacing_values %}
+            <option value="{{ f.line_spacing_value }}" selected>自訂（{{ f.line_spacing_value }}）</option>
+            {% endif %}
+          </select>
+          <button class="btn btn-sm btn-outline-primary" type="submit">套用</button>
+        </form>
+        <div class="small text-muted mt-1">目前：{{ f.format_label }}，{{ f.line_spacing_label }}</div>
+      </td>
+      <td class="align-middle">
         <form action="{{ url_for('execute_flow', task_id=task.id, flow_name=f.name) }}" method="post" class="d-inline" {% if f.has_copy %}onsubmit="return confirm('此流程包含複製檔案步驟，確定要執行嗎？');"{% endif %}>
           <button class="btn btn-sm btn-outline-success">執行</button>
         </form>
@@ -92,7 +135,7 @@
         </td>
       </tr>
     {% else %}
-    <tr><td colspan="3">尚無流程</td></tr>
+    <tr><td colspan="4">尚無流程</td></tr>
   {% endfor %}
   </tbody>
 </table>
@@ -114,6 +157,33 @@ const TASK_ID = '{{ task.id }}';
 const SUPPORTED_STEPS = {{ steps|tojson }};
 const AVAILABLE_FILES = {{ files|tojson }};
 const PRESET_FLOW = {{ preset|tojson }};
+const FORMAT_PRESETS = {{ format_presets|tojson }};
+
+function updateDocumentFormatHelp(){
+  const select = document.getElementById('document_format');
+  const help = document.getElementById('document_format_help');
+  if (!select || !help) return;
+  const meta = FORMAT_PRESETS[select.value];
+  if (!meta){
+    help.textContent = '';
+    return;
+  }
+  const parts = [
+    `西文：${meta.western_font}`,
+    `中文：${meta.east_asian_font}`,
+    `字體大小 ${meta.font_size} pt`,
+  ];
+  if (typeof meta.space_before !== 'undefined' && typeof meta.space_after !== 'undefined'){
+    parts.push(`段前 ${meta.space_before} pt`, `段後 ${meta.space_after} pt`);
+  }
+  help.textContent = parts.join('，');
+}
+
+updateDocumentFormatHelp();
+const documentFormatSelect = document.getElementById('document_format');
+if (documentFormatSelect){
+  documentFormatSelect.addEventListener('change', updateDocumentFormatHelp);
+}
 let isInitialising = true;
 let isDirty = false;
 function markDirty(){

--- a/tests/test_format_settings.py
+++ b/tests/test_format_settings.py
@@ -1,0 +1,28 @@
+from app import (
+    DOCUMENT_FORMAT_PRESETS,
+    DEFAULT_DOCUMENT_FORMAT_KEY,
+    DEFAULT_LINE_SPACING,
+    coerce_line_spacing,
+    normalize_document_format,
+)
+
+
+def test_normalize_document_format_handles_unknown_keys():
+    assert normalize_document_format(None) == DEFAULT_DOCUMENT_FORMAT_KEY
+    assert normalize_document_format("") == DEFAULT_DOCUMENT_FORMAT_KEY
+    assert normalize_document_format("unknown") == DEFAULT_DOCUMENT_FORMAT_KEY
+    for key in DOCUMENT_FORMAT_PRESETS:
+        assert normalize_document_format(key) == key
+
+
+def test_coerce_line_spacing_returns_valid_float():
+    assert coerce_line_spacing("2") == 2.0
+    assert coerce_line_spacing("1.25") == 1.25
+    assert coerce_line_spacing(1.1) == 1.1
+
+
+def test_coerce_line_spacing_defaults_on_invalid_values():
+    assert coerce_line_spacing(None) == DEFAULT_LINE_SPACING
+    assert coerce_line_spacing("not-a-number") == DEFAULT_LINE_SPACING
+    assert coerce_line_spacing(0) == DEFAULT_LINE_SPACING
+    assert coerce_line_spacing(-1) == DEFAULT_LINE_SPACING

--- a/tests/test_update_flow_format.py
+++ b/tests/test_update_flow_format.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+
+from app import app, DEFAULT_DOCUMENT_FORMAT_KEY, DOCUMENT_FORMAT_PRESETS
+
+
+@pytest.fixture
+def task_env(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    output_dir = tmp_path / "output"
+    tasks_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+
+    old_task_folder = app.config["TASK_FOLDER"]
+    old_output_folder = app.config["OUTPUT_FOLDER"]
+
+    app.config["TASK_FOLDER"] = str(tasks_dir)
+    app.config["OUTPUT_FOLDER"] = str(output_dir)
+
+    try:
+        yield tasks_dir
+    finally:
+        app.config["TASK_FOLDER"] = old_task_folder
+        app.config["OUTPUT_FOLDER"] = old_output_folder
+
+
+def _write_json(path, data):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+
+
+def test_update_flow_format_updates_existing_metadata(task_env):
+    task_id = "abc123"
+    flow_dir = task_env / task_id / "flows"
+    flow_dir.mkdir(parents=True)
+    flow_path = flow_dir / "demo.json"
+
+    original = {
+        "created": "2024-01-01 12:00",
+        "steps": [{"type": "insert_title", "params": {"text": "Demo"}}],
+        "center_titles": False,
+        "document_format": DEFAULT_DOCUMENT_FORMAT_KEY,
+        "line_spacing": 1.5,
+    }
+    _write_json(flow_path, original)
+
+    with app.test_client() as client:
+        response = client.post(
+            f"/tasks/{task_id}/flows/update-format/demo",
+            data={"document_format": "modern", "line_spacing": "2"},
+        )
+
+    assert response.status_code == 302
+
+    with open(flow_path, "r", encoding="utf-8") as fh:
+        updated = json.load(fh)
+
+    assert updated["document_format"] == "modern"
+    assert updated["line_spacing"] == 2.0
+    assert updated["center_titles"] is False
+    assert updated["created"] == original["created"]
+    assert updated["steps"] == original["steps"]
+
+
+def test_update_flow_format_converts_legacy_flow_list(task_env):
+    task_id = "legacy"
+    flow_dir = task_env / task_id / "flows"
+    flow_dir.mkdir(parents=True)
+    flow_path = flow_dir / "legacy.json"
+
+    legacy_steps = [{"type": "insert_title", "params": {"text": "Legacy"}}]
+    _write_json(flow_path, legacy_steps)
+
+    with app.test_client() as client:
+        response = client.post(
+            f"/tasks/{task_id}/flows/update-format/legacy",
+            data={
+                "document_format": list(DOCUMENT_FORMAT_PRESETS.keys())[0],
+                "line_spacing": "1.25",
+            },
+        )
+
+    assert response.status_code == 302
+
+    with open(flow_path, "r", encoding="utf-8") as fh:
+        updated = json.load(fh)
+
+    assert isinstance(updated, dict)
+    assert updated["steps"] == legacy_steps
+    assert updated["document_format"] in DOCUMENT_FORMAT_PRESETS
+    assert updated["line_spacing"] == 1.25
+    assert updated["center_titles"] is True
+    assert isinstance(updated.get("created"), str)


### PR DESCRIPTION
## Summary
- expose stored document format and line spacing for saved flows with inline controls to reapply presets
- add a backend endpoint that updates legacy flow definitions with the selected formatting metadata
- cover the new formatting update workflow with Flask tests

## Testing
- pytest *(fails: pre-existing insert_title and mapping_processor suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c9354c33ac8323ba2805bfee5add05