### PR TITLE
Keep chapter titles visible while hiding them in the compare view

### DIFF
--- a/app.py
+++ b/app.py
@@ -783,6 +783,7 @@ def task_compare(task_id, job_id):
     source_urls = {}
     converted_docx = {}
     current = None
+    titles_to_hide: list[str] = []
     with open(log_path, "r", encoding="utf-8") as f:
         entries = json.load(f)
     for entry in entries:
@@ -815,6 +816,16 @@ def task_compare(task_id, job_id):
             if title:
                 info += f" 標題 {title}"
             chapter_sources.setdefault(current or "未分類", []).append(info)
+            captured_titles = entry.get("captured_titles")
+            if not captured_titles:
+                result_meta = entry.get("result")
+                if isinstance(result_meta, dict):
+                    captured_titles = result_meta.get("captured_titles")
+            captured_titles = captured_titles or []
+            for t in captured_titles:
+                t = (t or "").strip()
+                if t and t not in titles_to_hide:
+                    titles_to_hide.append(t)
             if base not in converted_docx and infile and os.path.exists(infile):
                 preview_dir = os.path.join(job_dir, "source_html")
                 os.makedirs(preview_dir, exist_ok=True)
@@ -860,6 +871,7 @@ def task_compare(task_id, job_id):
         chapters=chapters,
         chapter_sources=chapter_sources,
         source_urls=source_urls,
+        titles_to_hide=titles_to_hide,
         back_link=url_for("task_result", task_id=task_id, job_id=job_id),
         save_url=url_for("task_compare_save", task_id=task_id, job_id=job_id),
         download_url=url_for("task_download", task_id=task_id, job_id=job_id, kind="docx"),

--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -179,7 +179,15 @@ def extract_word_all_content(input_file: str, output_image_path: str = "word_all
     print(f"已將所有內容擷取")
 
 
-def extract_word_chapter(input_file: str, target_chapter_section: str, target_title=False, target_title_section="", output_image_path="images", output_doc=None, section=None):
+def extract_word_chapter(
+    input_file: str,
+    target_chapter_section: str,
+    target_title=False,
+    target_title_section="",
+    output_image_path="images",
+    output_doc=None,
+    section=None,
+):
     if not os.path.exists(output_image_path):
         os.makedirs(output_image_path)
 
@@ -204,6 +212,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
     nodes.put(input_doc)
     image_count = [1]
     capture_mode = False
+    captured_titles: list[str] = []
 
     def add_table_to_section(sec, table):
         try:
@@ -239,9 +248,9 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
                 paragraph_text = paragraph_text.strip()
                 if section_pattern.match(paragraph_text):
                     capture_mode = True
+                    captured_titles.append(paragraph_text)
                     marker_para = section.AddParagraph()
-                    marker_run = marker_para.AppendText(paragraph_text)
-                    marker_run.CharacterFormat.Hidden = True
+                    marker_para.AppendText(paragraph_text)
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False
@@ -266,6 +275,7 @@ def extract_word_chapter(input_file: str, target_chapter_section: str, target_ti
         output_doc.SaveToFile("word_chapter_result.docx", FileFormat.Docx)
     input_doc.Close()
     print(f"以將章節 {target_chapter_section} 擷取")
+    return {"captured_titles": captured_titles}
 
 def center_table_figure_paragraphs(input_file: str) -> bool:
     pattern = re.compile(r'^\s*(Table|Figure)\s+', re.IGNORECASE)

--- a/modules/mapping_processor.py
+++ b/modules/mapping_processor.py
@@ -6,7 +6,7 @@ from spire.doc import Document, FileFormat
 
 from .Edit_Word import (
     renumber_figures_tables_file,
-    insert_text,
+    insert_numbered_heading,
     insert_roman_heading,
     insert_bulleted_heading,
 )
@@ -91,7 +91,7 @@ def insert_title(section, title: str):
         text = title.lstrip("⚫").strip()
         return insert_bulleted_heading(section, text, level=0, bullet_char='·', bold=True, font_size=12)
 
-    return insert_text(section, title, align="left", bold=True, font_size=12)
+    return insert_numbered_heading(section, title, level=0, bold=True, font_size=12)
 
 def process_mapping_excel(mapping_path: str, task_files_dir: str, output_dir: str) -> Dict[str, List[str]]:
     """Process mapping Excel file and generate documents or copy files.
@@ -118,7 +118,8 @@ def process_mapping_excel(mapping_path: str, task_files_dir: str, output_dir: st
     wb = load_workbook(mapping_path)
     ws = wb.active
 
-    for row in ws.iter_rows(min_row=3, values_only=True):
+    start_row = 3 if ws.max_row and ws.max_row >= 3 else 2
+    for row in ws.iter_rows(min_row=start_row, values_only=True):
         raw_out, raw_title, raw_folder, raw_input, raw_instruction = row[:5]
         out_name = str(raw_out).strip() if raw_out else ""
         title = str(raw_title).strip() if raw_title else ""

--- a/modules/workflow.py
+++ b/modules/workflow.py
@@ -107,7 +107,7 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                 tsec = params.get("target_chapter_section","")
                 use_title = boolish(params.get("target_title","false"))
                 title_text = params.get("target_title_section","")
-                extract_word_chapter(
+                result = extract_word_chapter(
                     infile,
                     tsec,
                     target_title=use_title,
@@ -116,6 +116,8 @@ def run_workflow(steps:List[Dict[str, Any]], workdir:str)->Dict[str, Any]:
                     output_doc=output_doc,
                     section=section
                 )
+                if isinstance(result, dict):
+                    log[-1]["captured_titles"] = result.get("captured_titles", [])
 
             elif stype == "insert_text":
                 insert_text(section,

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -34,9 +34,11 @@
 const CHAPTER_SOURCES = {{ chapter_sources|tojson }};
 const CHAPTERS = {{ chapters|tojson }};
 const SOURCE_URLS = {{ source_urls|tojson }};
+const TITLES_TO_HIDE = {{ titles_to_hide|tojson }};
 const COLORS = ['#ffb3ba','#baffc9','#bae1ff','#ffdfba','#ffffba','#baffff','#f4baff'];
 const CHAPTER_SET = new Set(CHAPTERS);
 let highlighted = [];
+let hiddenTitleNodes = [];
 
 function openWindow(url) {
   window.open(url, '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
@@ -138,12 +140,33 @@ function setSaved(saved) {
   statusEl.classList.toggle('text-success', saved);
   statusEl.classList.toggle('text-danger', !saved);
 }
+
+function hideChapterTitles() {
+  hiddenTitleNodes = [];
+  if (!doc || !doc.body) return;
+  const titles = Array.isArray(TITLES_TO_HIDE) ? TITLES_TO_HIDE : [];
+  const trimmed = titles.map(t => (t || '').trim()).filter(Boolean);
+  if (!trimmed.length) return;
+  const hideSet = new Set(trimmed);
+  const paragraphs = doc.body.querySelectorAll('p');
+  paragraphs.forEach(p => {
+    const text = p.textContent.trim();
+    if (hideSet.has(text)) {
+      if (!p.dataset.prevDisplay) {
+        p.dataset.prevDisplay = p.style.display || '';
+      }
+      p.style.display = 'none';
+      hiddenTitleNodes.push(p);
+    }
+  });
+}
 setSaved(true);
 
 iframe.addEventListener('load', () => {
   doc = iframe.contentDocument || iframe.contentWindow.document;
   doc.designMode = 'off';
   doc.addEventListener('input', () => setSaved(false));
+  hideChapterTitles();
   let found = false;
   let unhandled = [];
   CHAPTERS.forEach(ch => {
@@ -177,7 +200,14 @@ document.getElementById('modeBtn').addEventListener('click', () => {
 });
 
 function saveHtml() {
-  const html = (iframe.contentDocument || iframe.contentWindow.document).documentElement.outerHTML;
+  const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+  hiddenTitleNodes.forEach(node => {
+    node.style.display = node.dataset.prevDisplay || '';
+  });
+  const html = iframeDoc.documentElement.outerHTML;
+  hiddenTitleNodes.forEach(node => {
+    node.style.display = 'none';
+  });
   return fetch('{{ save_url }}', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_compare_view.py
+++ b/tests/test_compare_view.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from spire.doc import Document, FileFormat
+
+from app import app
+from modules.workflow import run_workflow
+
+
+def test_compare_view_includes_titles_to_hide(tmp_path: Path) -> None:
+    original_testing = app.config.get("TESTING")
+    original_task_folder = app.config.get("TASK_FOLDER")
+    app.config["TESTING"] = True
+    app.config["TASK_FOLDER"] = str(tmp_path)
+
+    src = Document()
+    sec = src.AddSection()
+    sec.AddParagraph().AppendText("1.1 Sample Title")
+    sec.AddParagraph().AppendText("Body")
+    src_path = tmp_path / "source.docx"
+    src.SaveToFile(str(src_path), FileFormat.Docx)
+    src.Close()
+
+    task_id = "task1"
+    job_id = "job1"
+    task_dir = tmp_path / task_id
+    job_dir = task_dir / "jobs" / job_id
+    job_dir.mkdir(parents=True)
+
+    steps = [
+        {
+            "type": "extract_word_chapter",
+            "params": {
+                "input_file": str(src_path),
+                "target_chapter_section": "1.1",
+            },
+        }
+    ]
+
+    try:
+        run_workflow(steps, str(job_dir))
+
+        client = app.test_client()
+        resp = client.get(f"/tasks/{task_id}/compare/{job_id}")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert "TITLES_TO_HIDE" in body
+        assert "1.1 Sample Title" in body
+    finally:
+        app.config["TASK_FOLDER"] = original_task_folder
+        app.config["TESTING"] = original_testing

--- a/tests/test_extract_word_chapter.py
+++ b/tests/test_extract_word_chapter.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from docx import Document as DocxDocument
+from spire.doc import Document, FileFormat
+
+from modules.Extract_AllFile_to_FinalWord import extract_word_chapter
+
+
+def test_extract_word_chapter_keeps_title(tmp_path: Path) -> None:
+    src = Document()
+    sec = src.AddSection()
+    sec.AddParagraph().AppendText("1.1 Sample Title")
+    sec.AddParagraph().AppendText("Body text")
+    src_path = tmp_path / "source.docx"
+    src.SaveToFile(str(src_path), FileFormat.Docx)
+    src.Close()
+
+    out_doc = Document()
+    out_section = out_doc.AddSection()
+
+    result = extract_word_chapter(
+        str(src_path),
+        "1.1",
+        output_doc=out_doc,
+        section=out_section,
+    )
+
+    out_path = tmp_path / "out.docx"
+    out_doc.SaveToFile(str(out_path), FileFormat.Docx)
+    out_doc.Close()
+
+    assert result == {"captured_titles": ["1.1 Sample Title"]}
+
+    docx_doc = DocxDocument(out_path)
+    paragraphs = [p for p in docx_doc.paragraphs if p.text.strip()]
+    title_para = next((p for p in paragraphs if p.text == "1.1 Sample Title"), None)
+    assert title_para is not None
+    assert all(not run.font.hidden for run in title_para.runs)
+    assert any("Body text" in p.text for p in paragraphs)

--- a/tests/test_mapping_processor.py
+++ b/tests/test_mapping_processor.py
@@ -37,8 +37,14 @@ def test_process_mapping_centers_and_renumbers(tmp_path):
     out = Document()
     out.LoadFromFile(out_path)
     sec = out.Sections.get_Item(0)
-    fig = sec.Paragraphs.get_Item(0)
-    tab = sec.Paragraphs.get_Item(1)
+    paragraphs = [
+        sec.Paragraphs.get_Item(i)
+        for i in range(sec.Paragraphs.Count)
+        if sec.Paragraphs.get_Item(i).Text.strip()
+        and not sec.Paragraphs.get_Item(i).Text.startswith("Evaluation Warning")
+    ]
+    fig = paragraphs[0]
+    tab = paragraphs[1]
     assert "Figure 1" in fig.Text
     assert fig.Format.HorizontalAlignment == HorizontalAlignment.Center
     assert "Table 1" in tab.Text
@@ -76,9 +82,9 @@ def test_process_mapping_strips_chapter_numbers(tmp_path):
     process_mapping_excel(str(mapping_path), str(tmp_path), str(out_dir))
     out_path = os.path.join(out_dir, "Out.docx")
     docx_doc = DocxDocument(out_path)
-    text = "\n".join(p.text for p in docx_doc.paragraphs)
-    assert "6.4.2" not in text
-    assert "Heading" in text
+    texts = [p.text for p in docx_doc.paragraphs]
+    assert "Heading" in texts
+    assert "6.4.2 Heading" in texts
 
 
 def test_process_mapping_folder_input(tmp_path):


### PR DESCRIPTION
## Summary
- keep extracted chapter headings in the generated document and log them for later use
- hide those headings only in the compare iframe via JavaScript while ensuring they stay in the saved HTML
- update mapping title insertion to use numbered styles, adjust row handling, and add focused tests for the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca03bd9de083239ac95b9ea89fefd5