### PR TITLE
Hide extracted headings in output documents

### DIFF
--- a/modules/Extract_AllFile_to_FinalWord.py
+++ b/modules/Extract_AllFile_to_FinalWord.py
@@ -250,7 +250,9 @@ def extract_word_chapter(
                     capture_mode = True
                     captured_titles.append(paragraph_text)
                     marker_para = section.AddParagraph()
-                    marker_para.AppendText(paragraph_text)
+                    text_range = marker_para.AppendText(paragraph_text)
+                    if text_range is not None:
+                        text_range.CharacterFormat.Hidden = True
                     continue
                 elif capture_mode and child.ListText and stop_pattern.match(child.ListText):
                     capture_mode = False

--- a/tests/test_extract_word_chapter.py
+++ b/tests/test_extract_word_chapter.py
@@ -6,7 +6,7 @@ from spire.doc import Document, FileFormat
 from modules.Extract_AllFile_to_FinalWord import extract_word_chapter
 
 
-def test_extract_word_chapter_keeps_title(tmp_path: Path) -> None:
+def test_extract_word_chapter_hides_title(tmp_path: Path) -> None:
     src = Document()
     sec = src.AddSection()
     sec.AddParagraph().AppendText("1.1 Sample Title")
@@ -35,5 +35,6 @@ def test_extract_word_chapter_keeps_title(tmp_path: Path) -> None:
     paragraphs = [p for p in docx_doc.paragraphs if p.text.strip()]
     title_para = next((p for p in paragraphs if p.text == "1.1 Sample Title"), None)
     assert title_para is not None
-    assert all(not run.font.hidden for run in title_para.runs)
+    assert any(run.font.hidden for run in title_para.runs)
+    assert all(run.font.hidden or not run.text.strip() for run in title_para.runs)
     assert any("Body text" in p.text for p in paragraphs)

--- a/tests/test_mapping_processor.py
+++ b/tests/test_mapping_processor.py
@@ -84,7 +84,7 @@ def test_process_mapping_strips_chapter_numbers(tmp_path):
     docx_doc = DocxDocument(out_path)
     texts = [p.text for p in docx_doc.paragraphs]
     assert "Heading" in texts
-    assert "6.4.2 Heading" in texts
+    assert "6.4.2 Heading" not in texts
 
 
 def test_process_mapping_folder_input(tmp_path):


### PR DESCRIPTION
## Summary
- mark captured chapter headings as hidden when extracting Word sections so they can be removed from final documents
- update unit tests to verify hidden headings and adjusted mapping expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca13ff948c8323b1eb24920d21dff5