### PR TITLE
Hide extracted titles in compare view and Word output

### DIFF
--- a/tests/test_extract_word_chapter.py
+++ b/tests/test_extract_word_chapter.py
@@ -35,5 +35,5 @@ def test_extract_word_chapter_keeps_title(tmp_path: Path) -> None:
     paragraphs = [p for p in docx_doc.paragraphs if p.text.strip()]
     title_para = next((p for p in paragraphs if p.text == "1.1 Sample Title"), None)
     assert title_para is not None
-    assert all(not run.font.hidden for run in title_para.runs)
+    assert all(run.font.hidden for run in title_para.runs)
     assert any("Body text" in p.text for p in paragraphs)

--- a/tests/test_remove_hidden_runs.py
+++ b/tests/test_remove_hidden_runs.py
@@ -24,3 +24,19 @@ def test_remove_hidden_runs_keeps_paragraph_in_table_cell(tmp_path: Path) -> Non
     # Even though all visible text was removed, the table cell must keep a paragraph
     assert len(cell_after.paragraphs) == 1
     assert cell_after.paragraphs[0].text == ""
+
+
+def test_remove_hidden_runs_preserves_titles(tmp_path: Path) -> None:
+    doc = Document()
+    para = doc.add_paragraph("1.1 Sample Title")
+    for run in para.runs:
+        run.font.hidden = True
+
+    doc_path = tmp_path / "title.docx"
+    doc.save(doc_path)
+
+    assert remove_hidden_runs(str(doc_path), preserve_texts=["1.1 Sample Title"])
+
+    updated = Document(doc_path)
+    assert updated.paragraphs[0].text == "1.1 Sample Title"
+    assert all(run.font.hidden for run in updated.paragraphs[0].runs)


### PR DESCRIPTION
## Summary
- collect captured titles from workflow logs and reuse them when hiding headings in the compare page and regenerated documents
- mark extracted chapter titles as hidden text and add helpers to keep or reapply the hidden flag during post-processing
- update the mapping processor and tests to respect hidden titles across generated outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca167bead88323ad907ae0c42cced1